### PR TITLE
Update api to include error types

### DIFF
--- a/course.yaml
+++ b/course.yaml
@@ -51,19 +51,27 @@ paths:
           schema:
             $ref: '#/definitions/Error'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges, owner mismatch
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "409":
-          description: "Conflict"
+          description: |
+            Conflict  
+            types: key duplicate
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "422":
-          description: "Unprocessable Entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error
           schema:
             $ref: '#/definitions/DetailedError'
           
@@ -96,9 +104,11 @@ paths:
             items:
               $ref: "#/definitions/Course"
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
   /courses/{id}:
     get:
       tags:
@@ -122,13 +132,17 @@ paths:
             schema:
               $ref: "#/definitions/Course"
           "401":
-            description: "Unauthorized"
+            description: |
+              Unauthorized  
+              types: authorization error
             schema:
-              $ref: '#/definitions/DetailedError'
+              $ref: '#/definitions/GenericError'
           "404":
-            description: "Not Found"
+            description: |
+              Not Found  
+              types: key not found
             schema:
-              $ref: '#/definitions/DetailedError'
+              $ref: '#/definitions/GenericError'
     delete:
       tags:
       - "Course Management"
@@ -148,22 +162,24 @@ paths:
       responses:
         "200":
           description: "OK"
-        "400":
-          description: "Bad Request"
-          schema:
-            $ref: '#/definitions/DetailedError'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges, owner mismatch
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
     put:
       tags:
       - "Course Management"
@@ -192,26 +208,34 @@ paths:
         "200":
           description: "OK"
         "400":
-          description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+          description: |
+            Bad Request  
+            types: path parameter mismatch  
+            Note: on deserialization exception, Error of schema "Error" is thrown
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges, owner mismatch
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           schema:
-            $ref: '#/definitions/DetailedError'
+            $ref: '#/definitions/GenericError'
         "422":
-          description: "Unprocessable Entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error
           schema:
             $ref: '#/definitions/DetailedError'
             
@@ -263,11 +287,35 @@ definitions:
     required:
       - code
       - message
+  GenericError:
+    type: object
+    properties:
+      type:
+        type: string
+        enum: [
+          "path parameter mismatch", 
+          "wrong object",
+          "authorization error",
+          "not enough privileges",
+          "owner mismatch",
+          "key not found",
+          "key duplicate",
+          "teapot"
+        ]
+      title:
+        type: string
+    required:
+      - code
+      - message
   DetailedError:
     type: object
     properties:
       type:
         type: string
+        enum: [
+          "validation error", 
+          "uneditable fields"
+        ]
       title:
         type: string
       invalidParams:
@@ -284,6 +332,18 @@ definitions:
         type: string
       reason:
         type: string
+#    Error:
+#      allOf:
+#        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
+#        - type: object
+#    GenericError:
+#      allOf:
+#        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'
+#        - type: object
+#    DetailedError:
+#      allOf:
+#        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/DetailedError'
+#        - type: object
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"

--- a/course.yaml
+++ b/course.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.3.3"
+  version: "0.4.0"
   title: "UC4"
 host: "uc4.cs.upb.de/api"
 basePath: "/course-management"

--- a/errors.yaml
+++ b/errors.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.4.1"
+  version: "0.4.0"
   title: "UC4"
 tags:
 - name: "Errors"

--- a/errors.yaml
+++ b/errors.yaml
@@ -1,0 +1,79 @@
+openapi: "3.0.0"
+info:
+  description: "This is the User API for UC4."
+  version: "0.4.1"
+  title: "UC4"
+tags:
+- name: "Errors"
+  description: "Everything about the user"
+  externalDocs:
+    description: "Find out more"
+    url: "https://github.com/upb-uc4"
+paths:
+  /users:
+    get:
+      tags:
+      - "Errors"
+      responses:
+        "200":
+          description: "Ok"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        name:
+          type: string
+        detail:
+          type: string
+      required:
+        - code
+        - message
+    GenericError:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [
+            "path parameter mismatch", 
+            "wrong object",
+            "authorization error",
+            "not enough privileges",
+            "owner mismatch",
+            "key not found",
+            "key duplicate",
+            "teapot"
+          ]
+        title:
+          type: string
+      required:
+        - code
+        - message
+    DetailedError:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [
+            "validation error", 
+            "uneditable fields"
+          ]
+        title:
+          type: string
+        invalidParams:
+          type: array
+          items:
+            $ref: "#/components/schemas/SimpleError"
+      required:
+        - code
+        - message
+    SimpleError:
+      type: object
+      properties:
+        name:
+          type: string
+        reason:
+          type: string
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.4.1"
+  version: "0.4.2"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/user-management

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -46,17 +46,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/GetAllUsersResponse'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
   /users/{username}:
     delete:
       tags:
@@ -75,28 +79,30 @@ paths:
       responses:
         "200":
           description: "OK"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DetailedError'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
   /role/{username}:  
     get:
       tags:
@@ -120,17 +126,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/Role'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
   /password/{username}:
     post:
       tags:
@@ -161,26 +171,32 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "403":
+          description: |
+            Forbidden  
+            types: not enough privileges
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity  
+            types: validation error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DetailedError'
-        "403":
-          description: "Forbidden"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DetailedError'    
-        "422":
-          description: "Unprocessable Entity"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DetailedError'    
   
   /students:
     post:
@@ -220,25 +236,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "409":
-          description: "Conflict"
+          description: |
+            Conflict  
+            types: key duplicate
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "422":
-          description: "Unprocessable Entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error
           content:
             application/json:
               schema:
@@ -261,17 +285,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/Student'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
   /students/{username}:
     get:
       tags:
@@ -295,17 +323,21 @@ paths:
                 schema:
                   $ref: '#/components/schemas/Student'
           "401":
-            description: "Unauthorized"
+            description: |
+              Unauthorized  
+              types: authorization error
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/DetailedError'
+                  $ref: '#/components/schemas/GenericError'
           "404":
-            description: "Not Found"
+            description: |
+              Not Found  
+              types: key not found
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/DetailedError'
+                  $ref: '#/components/schemas/GenericError'
     put:
       tags:
       - "Student Management"
@@ -333,32 +365,43 @@ paths:
         "200":
           description: "OK"
         "400":
-          description: "Bad Request"
+          description: |
+            Bad Request  
+            types: path parameter mismatch  
+            Note: on deserialization exception, Error of schema "Error" is thrown
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "422":
-          description: "Unprocessable Entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error, uneditable fields
           content:
             application/json:
               schema:
@@ -401,25 +444,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "409":
-          description: "Conflict"
+          description: |
+            Conflict  
+            types: key duplicate
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "422":
-          description: "Unprocessable Entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error
           content:
             application/json:
               schema:
@@ -442,17 +493,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/Lecturer'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
   /lecturers/{username}:
     get:
       tags:
@@ -476,17 +531,21 @@ paths:
                 schema:
                   $ref: '#/components/schemas/Lecturer'
           "401":
-            description: "Unauthorized"
+            description: |
+              Unauthorized  
+              types: authorization error
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/DetailedError'
+                  $ref: '#/components/schemas/GenericError'
           "404":
-            description: "Not Found"
+            description: |
+              Not Found  
+              types: key not found
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/DetailedError'
+                  $ref: '#/components/schemas/GenericError'
     put:
       tags:
       - "Lecturer Management"
@@ -514,31 +573,42 @@ paths:
         "200":
           description: "OK"
         "400":
-          description: "Bad Request"
+          description: |
+            Bad Request  
+            types: path parameter mismatch  
+            Note: on deserialization exception, Error of schema "Error" is thrown
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "422":
-          description: "Unprocessable entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error, uneditable fields
           content:
             application/json:
               schema:
@@ -582,25 +652,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "409":
-          description: "Conflict"
+          description: |
+            Conflict  
+            types: key duplicate
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "422":
-          description: "Unprocessable Entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error
           content:
             application/json:
               schema:
@@ -623,17 +701,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/Admin'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
   /admins/{username}:
     get:
       tags:
@@ -657,17 +739,21 @@ paths:
                 schema:
                   $ref: '#/components/schemas/Admin'
           "401":
-            description: "Unauthorized"
+            description: |
+              Unauthorized  
+              types: authorization error
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/DetailedError'
+                  $ref: '#/components/schemas/GenericError'
           "404":
-            description: "Not Found"
+            description: |
+              Not Found  
+              types: key not found
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/DetailedError'
+                  $ref: '#/components/schemas/GenericError'
     put:
       tags:
       - "Admin Management"
@@ -692,31 +778,42 @@ paths:
         "200":
           description: "OK"
         "400":
-          description: "Bad Request"
+          description: |
+            Bad Request  
+            types: path parameter mismatch  
+            Note: on deserialization exception, Error of schema "Error" is thrown
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "401":
-          description: "Unauthorized"
+          description: |
+            Unauthorized  
+            types: authorization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "403":
-          description: "Forbidden"
+          description: |
+            Forbidden  
+            types: not enough privileges
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "404":
-          description: "Not Found"
+          description: |
+            Not Found  
+            types: key not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "422":
-          description: "Unprocessable entity"
+          description: |
+            Unprocessable Entity  
+            types: validation error
           content:
             application/json:
               schema:
@@ -820,37 +917,6 @@ components:
               type: string
             researchArea:
               type: string
-    Error:
-      type: object
-      properties:
-        name:
-          type: string
-        detail:
-          type: string
-      required:
-        - code
-        - message
-    DetailedError:
-      type: object
-      properties:
-        type:
-          type: string
-        title:
-          type: string
-        invalidParams:
-          type: array
-          items:
-            $ref: "#/components/schemas/SimpleError"
-      required:
-        - code
-        - message
-    SimpleError:
-      type: object
-      properties:
-        name:
-          type: string
-        reason:
-          type: string
     Address:
       type: object
       properties:
@@ -880,6 +946,74 @@ components:
         role:
           type: "string"
           enum: ["Admin", "Student", "Lecturer"]
+    Error:
+      type: object
+      properties:
+        name:
+          type: string
+        detail:
+          type: string
+      required:
+        - code
+        - message
+    GenericError:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [
+            "path parameter mismatch", 
+            "wrong object",
+            "authorization error",
+            "not enough privileges",
+            "owner mismatch",
+            "key not found",
+            "key duplicate",
+            "teapot"
+          ]
+        title:
+          type: string
+      required:
+        - code
+        - message
+    DetailedError:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [
+            "validation error", 
+            "uneditable fields"
+          ]
+        title:
+          type: string
+        invalidParams:
+          type: array
+          items:
+            $ref: "#/components/schemas/SimpleError"
+      required:
+        - code
+        - message
+    SimpleError:
+      type: object
+      properties:
+        name:
+          type: string
+        reason:
+          type: string
+#    Error:
+#      allOf:
+#        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
+#        - type: object
+#    GenericError:
+#      allOf:
+#        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'
+#        - type: object
+#    DetailedError:
+#      allOf:
+#        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/DetailedError'
+#        - type: object
+       
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"


### PR DESCRIPTION
### Reason for this PR
- New error types were defined, without the field "invalidParams"

### Changes in this PR
- Add GenericError errortype to api
- Create error.yaml file for the error models
- List the possible contents for the 'type' field on every response

Note: 
Currently, the import of the errors cannot be done, since the error.yaml file has to be on develop. Therefore, the errors are defined in course.yaml and in user-management.yaml
Once this PR is merged and the errors.yaml file is on develop, the imports can be done properly 