### PR TITLE
Fix endpoint path in matriculation api, fix matriculation api not bei…

### DIFF
--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -31,7 +31,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JsonVersionNumber'
-  /immatriculation/{username}:
+  /{username}:
     put:
       tags:
       - "Matriculation Management"
@@ -100,7 +100,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DetailedError'
-  /immatriculation/history/{username}:
+  /history/{username}:
     get:
       tags:
       - "Matriculation Management"

--- a/swagger-config.yaml
+++ b/swagger-config.yaml
@@ -9,3 +9,5 @@ urls:
       url: https://raw.githubusercontent.com/upb-uc4/api/develop/hl-course-management.yaml
     - name: Hyperledger-Management
       url: https://raw.githubusercontent.com/upb-uc4/api/develop/hyperledger-management.yaml
+    - name: Matriculation-Management
+      url: https://raw.githubusercontent.com/upb-uc4/api/develop/matriculation-management.yaml


### PR DESCRIPTION
### Reason for this PR
- The matriculation-management was not listed in swagger online
- Endpoints paths had a redundant "/immatriculation" path

### Changes in this PR
- Added matriculation-management to the config
- Deleted redundant "/immatriculation" in path