### PR TITLE
Add new errors for failing deserilization

### DIFF
--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Authentication API for UC4."
-  version: "0.5.0"
+  version: "0.5.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/authentication-management
@@ -60,13 +60,12 @@ paths:
         "400":
           description: | 
             Bad Request 
-            
-            detail contains deserialization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-        
+               oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -108,10 +107,6 @@ components:
         role:
           type: "string"
           enum: ["Admin", "Student", "Lecturer"]
-    Error:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
-        - type: object
     GenericError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'

--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Authentication API for UC4."
-  version: "0.5.1"
+  version: "0.6.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/authentication-management

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.5.2"
+  version: "0.6.1"
   title: "UC4"
 
 servers:

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.5.1"
+  version: "0.5.2"
   title: "UC4"
 
 servers:
@@ -65,13 +65,13 @@ paths:
                 description: "URI of the newly created course"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+            Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -252,12 +252,12 @@ paths:
         "400":
           description: | 
             Bad Request 
-            
-            detail contains deserialization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -336,10 +336,6 @@ components:
       properties:
         versionNumber:
           type: string
-    Error:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
-        - type: object
     GenericError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'

--- a/errors.yaml
+++ b/errors.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.5.1"
+  version: "0.6.1"
   title: "UC4"
 tags:
 - name: "Errors"

--- a/errors.yaml
+++ b/errors.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.4.0"
+  version: "0.5.1"
   title: "UC4"
 tags:
 - name: "Errors"
@@ -19,16 +19,6 @@ paths:
           description: "Ok"
 components:
   schemas:
-    Error:
-      type: object
-      properties:
-        name:
-          type: string
-        detail:
-          type: string
-      required:
-        - code
-        - message
     GenericError:
       type: object
       properties:

--- a/hl-course-management.yaml
+++ b/hl-course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Hl-Course API for UC4."
-  version: "0.5.2"
+  version: "0.6.1"
   title: "UC4"
   
 servers:

--- a/hl-course-management.yaml
+++ b/hl-course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Hl-Course API for UC4."
-  version: "0.5.1"
+  version: "0.5.2"
   title: "UC4"
   
 servers:
@@ -65,13 +65,13 @@ paths:
                 description: "URI of the newly created course"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+            Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -252,12 +252,12 @@ paths:
         "400":
           description: | 
             Bad Request 
-            
-            detail contains deserialization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -336,10 +336,6 @@ components:
       properties:
         versionNumber:
           type: string
-    Error:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
-        - type: object
     GenericError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'

--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Matriculation API for UC4."
-  version: "0.5.0"
+  version: "0.5.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/matriculation-management
@@ -75,7 +75,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -186,10 +188,6 @@ components:
           type: array
           items:
             type: string
-    Error:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
-        - type: object
     GenericError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'

--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Matriculation API for UC4."
-  version: "0.5.1"
+  version: "0.6.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/matriculation-management

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.5.3"
+  version: "0.6.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/user-management

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.5.2"
+  version: "0.5.3"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/user-management
@@ -199,12 +199,12 @@ paths:
         "400":
           description: | 
             Bad Request 
-            
-            detail contains deserialization error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -343,13 +343,13 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+            Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         
         "401":
           description: |
@@ -419,7 +419,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -558,13 +560,13 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+            Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -628,13 +630,13 @@ paths:
                 description: "URI of the newly created Admin"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+            Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -770,13 +772,13 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error
+            Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
         "401":
           description: |
             Unauthorized  
@@ -937,10 +939,6 @@ components:
       properties:
         versionNumber:
           type: string
-    Error:
-      allOf:
-        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/Error'
-        - type: object
     GenericError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'


### PR DESCRIPTION
### Reason for this PR
- Lagom deserilization can now support our agreed upon custom errors

### Changes in this PR
- Removed outdated Errors in all affected files

Note: This will probably be the first feature in the new sprint, causing all apis to be version 0.6.1
