### PR TITLE
Adapt API to JWT authentication

### DIFF
--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Authentication API for UC4."
-  version: "0.6.1"
+  version: "0.6.2"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/authentication-management
@@ -46,7 +46,7 @@ paths:
         schema:
           type: "string"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: []
       requestBody:
         description: "AuthenticationUser with the new password and the same role."
         required: true
@@ -59,7 +59,8 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request 
+            Bad Request  
+            types: malformed refresh token
           content:
             application/json:
               schema:
@@ -69,7 +70,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -85,17 +86,96 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DetailedError'
+  /login:
+    get:
+      tags:
+      - "Authentication Management"
+      summary: "Retrieve login and refresh token"
+      security:
+        - uc4_basic: [] 
+      description: "Provides the user with login credientals, thereby the user retrieves a login and refresh token as HTTP cookies. All further calls to API use the login token to authenticate the user. The refresh token can be used to request a new login token."
+      operationId: "login"
+      responses:
+        "200":
+          description: "OK"
+        "401":
+          description: |
+            Unauthorized  
+            types: basic authorization error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+  /refresh:
+    get:
+      tags:
+      - "Authentication Management"
+      summary: "Retrieve new login token"
+      security:
+        - uc4_token_refresh: []
+      description: "Provides the user with a new valid login token. The long lived refresh token is used to request a new short lived login token."
+      operationId: "refresh"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonUsername'
+        "400":
+          description: |
+            Bad Request  
+            types: malformed refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "401":
+          description: |
+            Unauthorized  
+            types: jwt authorization error, login token expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity  
+            types: refresh token signature invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+  /logout:
+    get:
+      tags:
+      - "Authentication Management"
+      summary: "Logout user"
+      security: [] 
+      description: "Invalidate the login and refresh token stored as HTTP cookies. "
+      operationId: "logout"
+      responses:
+        "200":
+          description: "OK"
 
 components:
   securitySchemes:
-    uc4_auth:
+    uc4_basic:
       type: http
       scheme: basic
+    uc4_token_login:
+      type: apiKey
+      in: cookie
+      name: login
+    uc4_token_refresh:
+      type: apiKey
+      in: cookie
+      name: refresh
   schemas:
     AuthUser:
       type: "object"
@@ -107,6 +187,11 @@ components:
         role:
           type: "string"
           enum: ["Admin", "Student", "Lecturer"]
+    JsonUsername:
+      type: "object"
+      properties:
+        username:
+           type: "string"
     GenericError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'

--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -103,6 +103,11 @@ paths:
       responses:
         "200":
           description: "OK"
+          headers: 
+            Set-Cookie:
+              schema: 
+                type: string
+                example: login=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbiIsImV4cCI6MTU5ODYxMzM2NSwidXNlcm5hbWUiOiJhZG1pbiIsImF1dGhlbnRpY2F0aW9uUm9sZSI6IkFkbWluIn0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI; Path=/, HttpOnly, Secure, SameSite=Strict; refresh=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJyZWZyZXNoIiwiZXhwIjoxNjAwMzQwNzY1LCJ1c2VybmFtZSI6ImFkbWluIiwiYXV0aGVudGljYXRpb25Sb2xlIjoiQWRtaW4ifQ.YGs4XDg95vvN_wkwHGBttoHxkUDxCGkWqqQugOEh0sE0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI; Path=/, HttpOnly, Secure, SameSite=Strict;
         "401":
           description: |
             Unauthorized  
@@ -127,6 +132,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JsonUsername'
+          headers: 
+            Set-Cookie:
+              schema: 
+                type: string
+                example: login=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbiIsImV4cCI6MTU5ODYxMzM2NSwidXNlcm5hbWUiOiJhZG1pbiIsImF1dGhlbnRpY2F0aW9uUm9sZSI6IkFkbWluIn0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI; Path=/, HttpOnly, Secure, SameSite=Strict;
         "400":
           description: |
             Bad Request  

--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -107,7 +107,7 @@ paths:
             Set-Cookie:
               schema: 
                 type: string
-                example: login=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbiIsImV4cCI6MTU5ODYxMzM2NSwidXNlcm5hbWUiOiJhZG1pbiIsImF1dGhlbnRpY2F0aW9uUm9sZSI6IkFkbWluIn0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI; Path=/, HttpOnly, Secure, SameSite=Strict; refresh=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJyZWZyZXNoIiwiZXhwIjoxNjAwMzQwNzY1LCJ1c2VybmFtZSI6ImFkbWluIiwiYXV0aGVudGljYXRpb25Sb2xlIjoiQWRtaW4ifQ.YGs4XDg95vvN_wkwHGBttoHxkUDxCGkWqqQugOEh0sE0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI; Path=/, HttpOnly, Secure, SameSite=Strict;
+                example: login=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbiIsImV4cCI6MTU5ODYxMzM2NSwidXNlcm5hbWUiOiJhZG1pbiIsImF1dGhlbnRpY2F0aW9uUm9sZSI6IkFkbWluIn0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI, Path=/, HttpOnly, Secure, SameSite=Strict; refresh=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJyZWZyZXNoIiwiZXhwIjoxNjAwMzQwNzY1LCJ1c2VybmFtZSI6ImFkbWluIiwiYXV0aGVudGljYXRpb25Sb2xlIjoiQWRtaW4ifQ.YGs4XDg95vvN_wkwHGBttoHxkUDxCGkWqqQugOEh0sE0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI, Path=/, HttpOnly, Secure, SameSite=Strict;
         "401":
           description: |
             Unauthorized  
@@ -136,7 +136,7 @@ paths:
             Set-Cookie:
               schema: 
                 type: string
-                example: login=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbiIsImV4cCI6MTU5ODYxMzM2NSwidXNlcm5hbWUiOiJhZG1pbiIsImF1dGhlbnRpY2F0aW9uUm9sZSI6IkFkbWluIn0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI; Path=/, HttpOnly, Secure, SameSite=Strict;
+                example: login=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbiIsImV4cCI6MTU5ODYxMzM2NSwidXNlcm5hbWUiOiJhZG1pbiIsImF1dGhlbnRpY2F0aW9uUm9sZSI6IkFkbWluIn0.hb1F2_wql4CwTcLXOPCqE7yRjYH3XL4jomexigKt6OI, Path=/, HttpOnly, Secure, SameSite=Strict;
         "400":
           description: |
             Bad Request  

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.6.1"
+  version: "0.6.2"
   title: "UC4"
 
 servers:
@@ -43,7 +43,7 @@ paths:
       description: "Adds a new course to the database after verification. ID field is not used and can be set arbitrarily"
       operationId: "addCourse"
       security:
-        - uc4_auth: []
+        - uc4_token_login: []
       requestBody:
         description: "Course object that needs to be added to the database"
         required: true
@@ -65,7 +65,8 @@ paths:
                 description: "URI of the newly created course"
         "400":
           description: | 
-            Bad Request
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -75,7 +76,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:  
               schema:
@@ -99,18 +100,20 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json: 
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
 
     get:
       tags:
       - "Course Management"
       summary: "Get all courses"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       description: "Returns all courses"
       operationId: "getAllCourses"
       parameters:
@@ -135,10 +138,26 @@ paths:
                 type: "array"
                 items:
                   $ref: '#/components/schemas/Course'
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types:  jwt authorization error, login token expired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
           content:
             application/json:
               schema:
@@ -148,7 +167,7 @@ paths:
       tags:
       - "Course Management"
       security:
-        - uc4_auth: []
+        - uc4_token_login: []
       summary: "Find course by course id"
       description: "Find course by course id"
       operationId: "findCourseByCourseId"
@@ -166,10 +185,18 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Course'
+          "400":
+            description: |
+              Bad Request    
+              types: malformed login token
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
           "401":
             description: |
               Unauthorized  
-              types: authorization error
+              types: jwt authorization error, login token expired
             content:
               application/json:
                 schema:
@@ -182,13 +209,21 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/GenericError'
+          "422":
+            description: |
+              Unprocessable Entity   
+              types: login token signature invalid
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
     delete:
       tags:
       - "Course Management"
       summary: "Deletes a course"
       description: ""
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       operationId: "deleteCourse"
       parameters:
       - name: "id"
@@ -200,10 +235,18 @@ paths:
       responses:
         "200":
           description: "OK"
+        "400":
+            description: |
+              Bad Request    
+              types: malformed login token
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -224,6 +267,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
+        "422":
+            description: |
+              Unprocessable Entity   
+              types: login token signature invalid
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
     put:
       tags:
       - "Course Management"
@@ -231,7 +282,7 @@ paths:
       description: ""
       operationId: "updateCourse"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       parameters:
       - name: "id"
         in: "path"
@@ -251,7 +302,8 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request 
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -261,7 +313,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -285,7 +337,7 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
@@ -293,9 +345,10 @@ paths:
 
 components:
   securitySchemes:
-    uc4_auth:
-      type: http
-      scheme: basic
+    uc4_token_login:
+      type: apiKey
+      in: cookie
+      name: login
   schemas:
     Course:
       type: "object"

--- a/errors.yaml
+++ b/errors.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.6.1"
+  version: "0.6.2"
   title: "UC4"
 tags:
 - name: "Errors"
@@ -25,6 +25,14 @@ components:
         type:
           type: string
           enum: [
+            "malformed refresh token",
+            "malformed login token",
+            "jwt authorization error",
+            "basic authorization error",
+            "refresh token expired",
+            "login token expired",
+            "refresh token signature invalid",
+            "login token signature invalid",
             "path parameter mismatch", 
             "wrong object",
             "authorization error",

--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Matriculation API for UC4."
-  version: "0.6.1"
+  version: "0.6.2"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/matriculation-management
@@ -39,7 +39,7 @@ paths:
       description: "Update MatriculationData with the given information, enrolling the student in the given semester, in the given fieldOfStudy. If MatriculationData does not exist, it will be created. Can only be invoked by Admins."
       operationId: "updateMatriculationData"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       requestBody:
         description: "PutMessageMatriculationData, containing the semester the student will be enrolled in, and the corresponding fieldOfStudy."
         required: true
@@ -71,7 +71,8 @@ paths:
           description: | 
             Bad Request 
             
-            detail contains deserialization error
+            detail contains deserialization error  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -81,7 +82,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -97,7 +98,7 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
@@ -107,7 +108,7 @@ paths:
       tags:
       - "Matriculation Management"
       security:
-        - uc4_auth: []
+        - uc4_token_login: []
       summary: "Get MatriculationData for the specified student"
       description: "Get MatriculationData of specified student."
       operationId: "getMatriculationData"
@@ -124,10 +125,18 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/MatriculationData'
+          "400":
+            description: |
+              Bad Request    
+              types: malformed login token
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
           "401":
             description: |
               Unauthorized  
-              types: authorization error
+              types: jwt authorization error, login token expired
             content:
               application/json:
                 schema:
@@ -148,11 +157,20 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/GenericError'
+          "422":
+            description: |
+              Unprocessable Entity  
+              types: login token signature invalid
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DetailedError'
 components:
   securitySchemes:
-    uc4_auth:
-      type: http
-      scheme: basic
+    uc4_token_login:
+      type: apiKey
+      in: cookie
+      name: login
   schemas:
     PutMessageMatriculationData:
       type: "object"

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.6.1"
+  version: "0.6.2"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/user-management
@@ -52,7 +52,7 @@ paths:
       - "User Management"
       summary: "Get all users"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all users, and may only be used by administrators. With \"usernames\" set, returns all users with the given usernames, which can be invoked by all roles."
       operationId: "getUsers"
       parameters:
@@ -71,10 +71,18 @@ paths:
                 type: "array"
                 items:
                   $ref: '#/components/schemas/GetAllUsersResponse'
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -87,6 +95,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   /users/{username}:
     delete:
       tags:
@@ -94,7 +110,7 @@ paths:
       summary: "Deletes a user"
       description: "Deletes a user (when invoked by an administrator)"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       operationId: "deleteUser"
       parameters:
       - name: "username"
@@ -105,10 +121,18 @@ paths:
       responses:
         "200":
           description: "OK"
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -129,6 +153,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   /role/{username}:  
     get:
       tags:
@@ -136,7 +168,7 @@ paths:
       summary: "Returns the role of a user"
       description: "Returns the role of the user with the specified username"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       operationId: "getRole"
       parameters:
       - name: "username"
@@ -151,10 +183,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Role'
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -163,6 +203,14 @@ paths:
           description: |
             Not Found  
             types: key not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
           content:
             application/json:
               schema:
@@ -176,7 +224,7 @@ paths:
       description: "Adds a new student to the database after verification."
       operationId: "addStudent"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       requestBody:
         description: "Student object that needs to be added to the database"
         required: true
@@ -198,7 +246,8 @@ paths:
                 description: "URI of the newly created Student"
         "400":
           description: | 
-            Bad Request 
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -208,7 +257,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -232,17 +281,19 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
     get:
       tags:
       - "Student Management"
       summary: "Get all students"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all students, and may only be used by administrators. With \"usernames\" set, returns all students with the given usernames, which can be invoked by all roles."
       operationId: "getStudents"
       parameters:
@@ -261,10 +312,18 @@ paths:
                 type: "array"
                 items:
                   $ref: '#/components/schemas/Student'
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -277,12 +336,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   /students/{username}:
     get:
       tags:
       - "Student Management"
       security:
-        - uc4_auth: []
+        - uc4_token_login: []
       summary: "Get student object of specific student"
       description: "Get student object of specific student"
       operationId: "getStudentByStudentName"
@@ -299,10 +366,18 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Student'
+          "400":
+            description: |
+              Bad Request    
+              types: malformed login token
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
           "401":
             description: |
               Unauthorized  
-              types: authorization error
+              types: jwt authorization error, login token expired
             content:
               application/json:
                 schema:
@@ -311,6 +386,14 @@ paths:
             description: |
               Not Found  
               types: key not found
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
+          "422":
+            description: |
+              Unprocessable Entity   
+              types: login token signature invalid
             content:
               application/json:
                 schema:
@@ -324,7 +407,7 @@ paths:
           Address, Email and profile picture
       operationId: "updateStudent"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       parameters:
       - name: "username"
         in: "path"
@@ -343,7 +426,8 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -354,7 +438,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -378,11 +462,13 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error, uneditable fields
+            types: validation error, uneditable fields, login token signature invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
   /lecturers:
     post:
       tags:
@@ -391,7 +477,7 @@ paths:
       description: "Adds a new lecturer to the database after verification."
       operationId: "addLecturer"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       requestBody:
         required: true
         description: "Lecturer object that needs to be added to the database"
@@ -415,7 +501,8 @@ paths:
           description: | 
             Bad Request 
             
-            detail contains deserialization error
+            detail contains deserialization error  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -425,7 +512,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -449,17 +536,19 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
     get:
       tags:
       - "Lecturer Management"
       summary: "Get all lecturers"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all lecturers, and may only be used by administrators. With \"usernames\" set, returns all lecturers with the given usernames, which can be invoked by all roles."
       operationId: "getLecturers"
       parameters:
@@ -478,10 +567,18 @@ paths:
                 type: "array"
                 items:
                   $ref: '#/components/schemas/Lecturer'
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -494,12 +591,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   /lecturers/{username}:
     get:
       tags:
       - "Lecturer Management"
       security:
-        - uc4_auth: []
+        - uc4_token_login: []
       summary: "Get lecturer object of specific username"
       description: "Get lecturer object of specific username"
       operationId: "getLecturerByUsername"
@@ -516,10 +621,18 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Lecturer'
+          "400":
+            description: |
+              Bad Request    
+              types: malformed login token
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
           "401":
             description: |
               Unauthorized  
-              types: authorization error
+              types: jwt authorization error, login token expired
             content:
               application/json:
                 schema:
@@ -528,6 +641,14 @@ paths:
             description: |
               Not Found  
               types: key not found
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
+          "422":
+            description: |
+              Unprocessable Entity   
+              types: login token signature invalid
             content:
               application/json:
                 schema:
@@ -541,7 +662,7 @@ paths:
           Address, Email and profile picture, free text and research area
       operationId: "updateLecturer"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       parameters:
       - name: "username"
         in: "path"
@@ -560,7 +681,8 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -570,7 +692,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -594,11 +716,13 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error, uneditable fields
+            types: validation error, uneditable fields, login token signature invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
 
   /admins:
     post:
@@ -608,7 +732,7 @@ paths:
       description: "Adds a new admin to the database after verification."
       operationId: "addAdmin"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       requestBody:
         required: true
         description: "Admin object that needs to be added to the database"
@@ -630,7 +754,8 @@ paths:
                 description: "URI of the newly created Admin"
         "400":
           description: | 
-            Bad Request
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -640,7 +765,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -664,17 +789,19 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
     get:
       tags:
       - "Admin Management"
       summary: "Get all admins"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all admins, and may only be used by administrators. With \"usernames\" set, returns all admins with the given usernames, which can be invoked by all roles."
       operationId: "getAdmins"
       parameters:
@@ -693,10 +820,18 @@ paths:
                 type: "array"
                 items:
                   $ref: '#/components/schemas/Admin'
+        "400":
+          description: |
+            Bad Request    
+            types: malformed login token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -709,12 +844,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: login token signature invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   /admins/{username}:
     get:
       tags:
       - "Admin Management"
       security:
-        - uc4_auth: []
+        - uc4_token_login: []
       summary: "Get admin object of specific username"
       description: "Get admin object of specific username"
       operationId: "getAdminByUsername"
@@ -731,10 +874,18 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Admin'
+          "400":
+            description: |
+              Bad Request    
+              types: malformed login token
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
           "401":
             description: |
               Unauthorized  
-              types: authorization error
+              types: jwt authorization error, login token expired
             content:
               application/json:
                 schema:
@@ -747,13 +898,21 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/GenericError'
+          "422":
+            description: |
+              Unprocessable Entity   
+              types: login token signature invalid
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenericError'
     put:
       tags:
       - "Admin Management"
       summary: "Update an existing admin"
       operationId: "updateAdmin"
       security:
-        - uc4_auth: [] 
+        - uc4_token_login: [] 
       parameters:
       - name: "username"
         in: "path"
@@ -772,7 +931,8 @@ paths:
           description: "OK"
         "400":
           description: | 
-            Bad Request
+            Bad Request  
+            types: malformed login token
           content:
             application/json:
               schema:
@@ -782,7 +942,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: authorization error
+            types: jwt authorization error, login token expired
           content:
             application/json:
               schema:
@@ -806,16 +966,19 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: validation error
+            types: validation error, login token signature invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
 components:
   securitySchemes:
-    uc4_auth:
-      type: http
-      scheme: basic
+    uc4_token_login:
+      type: apiKey
+      in: cookie
+      name: login
   schemas:
     GetAllUsersResponse:
       type: "object"


### PR DESCRIPTION
### Reason for this PR
- Lagom now uses token authentication

### Changes in this PR
- AuthenticationService now provides additional endpoints:
  - `login`: retrieve login and refresh token
  - `refresh`: retrieve new login token
  - `logout`: invalidate tokens
 - All other API endpoints now
   - expect token authentication
   - return specific errors if the token authentication fails
