### PR TITLE
Add detailed specification for name of invalidParam in DetailedError

### DIFF
--- a/hyperledger_matriculation_api.md
+++ b/hyperledger_matriculation_api.md
@@ -215,3 +215,16 @@ This method adds a single entry to the list of semesters in the MatriculationDat
   ]
 }
 ```
+
+### InvalidParameter
+```json
+{
+  "name": "string",
+  "reason": "string"
+}
+```
+name:
+- name of the invalid parameter in simple dot- and array notation, i.e. if the second semester entry in the ```semesters``` field of the first ```SubjectMatriculation``` object in the ```matriculationStatus``` field of a ```MatriculationData``` object is invalid, the ```name``` field of the ```InvalidParameter``` object would be ```"matriculationStatus[0].semesters[1]"```
+
+reason:
+- a textual representation of why the parameter is invalid


### PR DESCRIPTION
Submitting multiple fields of study in one addMatriculationData/updateMatriculationData transaction requires a precise format for the name field within the invalidParams field in the detailed error, such that it specifies exactly which field is invalid.

Discussion needed