### PR TITLE
Add transient specification

### DIFF
--- a/hyperledger_matriculation_api.md
+++ b/hyperledger_matriculation_api.md
@@ -24,7 +24,7 @@ In the following, the chaincode api is described. It is identical to the hyperle
 
 ### Add Matriculation Data
 - ID = addMatriculationData
-- Send
+- Send (*transient*)
     - MatriculationData
 - Receive
     - ""
@@ -64,7 +64,7 @@ In the following, the chaincode api is described. It is identical to the hyperle
 
 ### Update Matriculation Data
 - ID = updateMatriculationData
-- Send
+- Send (*transient*)
     - MatriculationData
 - Receive
     - ""


### PR DESCRIPTION
### Reason for this PR
- some sensitive data must never be stored on the chain, thus it must be transferred using the transient data field

### Changes in this PR
- mark transactions expecting argument transmission via transient data field as *transient*