### PR TITLE
Update error types for API calls

### DIFF
--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Authentication API for UC4."
-  version: "0.6.2"
+  version: "0.7.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/authentication-management
@@ -60,7 +60,7 @@ paths:
         "400":
           description: | 
             Bad Request  
-            types: MalformedRefreshToken
+            types: MalformedLoginToken, Deserialization, JsonValidation
           content:
             application/json:
               schema:
@@ -78,19 +78,21 @@ paths:
         "403":
           description: |
             Forbidden  
-            types: NotEnoughPrivileges
+            types: OwnerMismatch
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericError'
         "422":
           description: |
-            Unprocessable Entity  
-            types: Validation, LoginTokenSignatureInvalid
+            Unprocessable Entity
+            types: Validation, PathParameterMismatch, UneditableFields, LoginTokenSignatureInvalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
   /login:
     get:
       tags:
@@ -148,7 +150,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: JwtAuthorization
+            types: JwtAuthorization, RefreshTokenExpired
           content:
             application/json:
               schema:

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.6.2"
+  version: "0.7.1"
   title: "UC4"
 
 servers:
@@ -66,7 +66,7 @@ paths:
         "400":
           description: | 
             Bad Request  
-            types: MalformedLoginToken
+            types: MalformedLoginToken, Deserialization, JsonValidation
           content:
             application/json:
               schema:
@@ -303,7 +303,7 @@ paths:
         "400":
           description: | 
             Bad Request  
-            types: MalformedLoginToken
+            types: MalformedLoginToken, Deserialization, PathParameterMismatch, JsonValidation
           content:
             application/json:
               schema:
@@ -341,7 +341,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
 
 components:
   securitySchemes:

--- a/errors.yaml
+++ b/errors.yaml
@@ -1,16 +1,16 @@
 openapi: "3.0.0"
 info:
-  description: "This is the User API for UC4."
-  version: "0.6.2"
+  description: "This is the Error Definition for the UC4 API."
+  version: "0.7.1"
   title: "UC4"
 tags:
 - name: "Errors"
-  description: "Everything about the user"
+  description: "Unused"
   externalDocs:
     description: "Find out more"
     url: "https://github.com/upb-uc4"
 paths:
-  /users:
+  /unused:
     get:
       tags:
       - "Errors"
@@ -25,6 +25,7 @@ components:
         type:
           type: string
           enum: [
+            "HLUnprocessableEntity",
             "MalformedRefreshToken",
             "MalformedLoginToken",
             "JwtAuthorization",
@@ -33,16 +34,31 @@ components:
             "LoginTokenExpired",
             "RefreshTokenSignatureInvalid",
             "LoginTokenSignatureInvalid",
-            "PathParameterMismatch", 
-            "UnexpectedEntity",
+            "PathParameterMismatch",
             "Authorization",
             "NotEnoughPrivileges",
             "OwnerMismatch",
             "KeyNotFound",
             "KeyDuplicate",
+            "Deserialization",
             "Teapot"
           ]
         title:
+          type: string
+      required:
+        - code
+        - message
+    InformativeError:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [
+            "UnexpectedEntity"
+          ]
+        title:
+          type: string
+        information:
           type: string
       required:
         - code
@@ -54,6 +70,7 @@ components:
           type: string
           enum: [
             "Validation", 
+            "JsonValidation",
             "UneditableFields"
           ]
         title:

--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Matriculation API for UC4."
-  version: "0.6.2"
+  version: "0.7.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/matriculation-management
@@ -69,10 +69,8 @@ paths:
                 description: "URI of the newly created MatriculationData"
         "400":
           description: | 
-            Bad Request 
-            
-            detail contains deserialization error  
-            types: MalformedLoginToken
+            Bad Request  
+            types: MalformedLoginToken, Deserialization, JsonValidation
           content:
             application/json:
               schema:
@@ -98,11 +96,13 @@ paths:
         "422":
           description: |
             Unprocessable Entity  
-            types: Validation, LoginTokenSignatureInvalid
+            types: Validation, LoginTokenSignatureInvalid, HLUnprocessableEntity
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
   /history/{username}:
     get:
       tags:
@@ -144,7 +144,7 @@ paths:
           "403":
             description: |
               Forbidden  
-              types: NotEnoughPrivileges
+              types: NotEnoughPrivileges, OwnerMismatch
             content:
               application/json:
                 schema:
@@ -152,7 +152,7 @@ paths:
           "404":
             description: |
               Not Found  
-              types: KeyNotFound
+              types: HLNotFound
             content:
               application/json:
                 schema:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.7.1"
+  version: "0.7.2"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/user-management
@@ -155,7 +155,7 @@ paths:
         "400":
           description: | 
             Bad Request  
-            types: MalformedLoginToken
+            types: MalformedLoginToken, Deserialization, JsonValidation
           content:
             application/json:
               schema:
@@ -193,7 +193,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
     
   /users/{username}:
     get:
@@ -298,14 +300,14 @@ paths:
         "400":
           description: | 
             Bad Request  
-            types: MalformedLoginToken
+            types: MalformedLoginToken, UnexpectedEntity, Deserialization, PathParameterMismatch, JsonValidation
           content:
             application/json:
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/GenericError'
                   - $ref: '#/components/schemas/DetailedError'
-        
+                  - $ref: '#/components/schemas/InformativeError'
         "401":
           description: |
             Unauthorized  
@@ -317,7 +319,7 @@ paths:
         "403":
           description: |
             Forbidden  
-            types: NotEnoughPrivileges
+            types: OwnerMismatch
           content:
             application/json:
               schema:
@@ -337,7 +339,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DetailedError'
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
     delete:
       tags:
       - "User Management"
@@ -764,6 +768,10 @@ components:
     DetailedError:
       allOf:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/DetailedError'
+        - type: object
+    InformativeError:
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/InformativeError'
         - type: object
   examples:
     ExamplePostMessageStudent:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -53,7 +53,7 @@ paths:
       - "User Management"
       summary: "Get all users"
       security:
-        - uc4_login_token: []
+        - uc4_token_login: []
       description: "Without parameter \"usernames\", returns all users, and may only be used by administrators. With \"usernames\" set, returns all users with the given usernames, which can be invoked by all roles."
       operationId: "getUsers"
       parameters:
@@ -111,7 +111,7 @@ paths:
       description: "Adds a new user to the database after verification."
       operationId: "addUser"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       requestBody:
         description: "User object that needs to be added to the database"
         required: true
@@ -202,7 +202,7 @@ paths:
       tags:
       - "User Management"
       security:
-        - uc4_login_token: []
+        - uc4_token_login: []
       summary: "Get user object for a specified username"
       description: "Get user object of specific user"
       operationId: "getUserByUsername"
@@ -270,7 +270,7 @@ paths:
           Address, Email and profile picture
       operationId: "updateUser"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       parameters:
       - name: "username"
         in: "path"
@@ -348,7 +348,7 @@ paths:
       summary: "Deletes a user"
       description: "Deletes a user (when invoked by an administrator)"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       operationId: "deleteUser"
       parameters:
       - name: "username"
@@ -406,7 +406,7 @@ paths:
       summary: "Returns the role of a user"
       description: "Returns the role of the user with the specified username"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       operationId: "getRole"
       parameters:
       - name: "username"
@@ -460,7 +460,7 @@ paths:
       - "Student Management"
       summary: "Get all students"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all students, and may only be used by administrators. With \"usernames\" set, returns all students with the given usernames, which can be invoked by all roles."
       operationId: "getStudents"
       parameters:
@@ -518,7 +518,7 @@ paths:
       - "Lecturer Management"
       summary: "Get all lecturers"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all lecturers, and may only be used by administrators. With \"usernames\" set, returns all lecturers with the given usernames, which can be invoked by all roles."
       operationId: "getLecturers"
       parameters:
@@ -576,7 +576,7 @@ paths:
       - "Admin Management"
       summary: "Get all admins"
       security:
-        - uc4_login_token: [] 
+        - uc4_token_login: [] 
       description: "Without parameter \"usernames\", returns all admins, and may only be used by administrators. With \"usernames\" set, returns all admins with the given usernames, which can be invoked by all roles."
       operationId: "getAdmins"
       parameters:
@@ -634,7 +634,6 @@ components:
       type: apiKey
       in: cookie
       name: login
-      
   schemas:
     GetAllUsersResponse:
       type: "object"


### PR DESCRIPTION
### Reason for this PR
- Some errors types were missing in the error definitions
- For some calls the API specified errors that are not thrown

### Changes in this PR
- Adapted API to specify the correct errors for this call
- Closes #32 
- Closes #29 