### PR TITLE
Add new "RefreshTokenMissing" error to api

### DIFF
--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Authentication API for UC4."
-  version: "0.8.1"
+  version: "0.8.2"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/authentication-management
@@ -177,7 +177,7 @@ paths:
         "401":
           description: |
             Unauthorized  
-            types: JwtAuthorization, RefreshTokenExpired
+            types: JwtAuthorization, RefreshTokenExpired, RefreshTokenMissing
           content:
             application/json:
               schema:

--- a/errors.yaml
+++ b/errors.yaml
@@ -30,6 +30,7 @@ components:
             "MalformedLoginToken",
             "JwtAuthorization",
             "BasicAuthorization",
+            "RefreshTokenMissing",
             "RefreshTokenExpired",
             "LoginTokenExpired",
             "RefreshTokenSignatureInvalid",


### PR DESCRIPTION
### Reason for this PR
- Lagom supports a new error

### Changes in this PR
- Added a new error in refresh with type "RefreshTokenMissing"
