### PR TITLE
Update UserService api to include new DELETE Image call

### DIFF
--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.8.2"
+  version: "0.9.1"
   title: "UC4"
 servers:
   - url: https://uc4.cs.upb.de/api/user-management
@@ -534,6 +534,11 @@ paths:
       responses:
         "200":
           description: "OK"
+          headers:
+            Location:
+              schema:
+                type: string
+              description: "URI of the new profile pricture"
         "400":
           description: | 
             Bad Request  
@@ -591,9 +596,68 @@ paths:
           content:
             application/json:
               schema:
+                $ref: '#/components/schemas/GenericError'
+    delete:
+      tags:
+      - "User Management"
+      summary: "Delete a profile picture"
+      description: |
+        Resets a user's profile picture back to the default.
+      operationId: "deleteImage"
+      security:
+        - uc4_token_login: [] 
+        - uc4_token_login_header: []
+      parameters:
+      - name: "username"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "OK"
+        "400":
+          description: | 
+            Bad Request  
+            types: MalformedLoginToken, MultipleAuthorizationError, Deserialization, MissingHeader
+          content:
+            application/json:
+              schema:
                 oneOf:
                   - $ref: '#/components/schemas/GenericError'
                   - $ref: '#/components/schemas/DetailedError'
+        "401":
+          description: |
+            Unauthorized  
+            types: JwtAuthorization, LoginTokenExpired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "403":
+          description: |
+            Forbidden  
+            types: OwnerMismatch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "404":
+          description: |
+            Not Found  
+            types: KeyNotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity  
+            types: LoginTokenSignatureInvalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   
   /students:
     get:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -619,13 +619,11 @@ paths:
         "400":
           description: | 
             Bad Request  
-            types: MalformedLoginToken, MultipleAuthorizationError, Deserialization, MissingHeader
+            types: MalformedLoginToken, MultipleAuthorizationError
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/GenericError'
-                  - $ref: '#/components/schemas/DetailedError'
+                $ref: '#/components/schemas/GenericError'
         "401":
           description: |
             Unauthorized  


### PR DESCRIPTION
### Reason for this PR
- While images were updatable, one was not able to delete their profile picture, or reset to default
- PUT call was missing the location header for the newly created image

### Changes in this PR
- Add location header to PUT image
- Add endpoint DELETE image, which deletes the profile picture, effectively resetting to default