### PR TITLE
Add exam reg management yaml

### DIFF
--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.8.2"
+  version: "0.11.1"
   title: "UC4"
 
 servers:
@@ -100,15 +100,11 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/GenericError'
                   - $ref: '#/components/schemas/DetailedError'
-
     get:
       tags:
       - "Course Management"
       summary: "Get all courses"
-      security:
-        - uc4_token_login: [] 
-        - uc4_token_login_header: []
-      description: "Returns all courses"
+      description: "Returns all courses, optionally filtered by query parameters"
       operationId: "getAllCourses"
       parameters:
       - name: "courseName"
@@ -123,6 +119,12 @@ paths:
         required: false
         schema:
           type: 'string'
+      - name: "modules"
+        in: "query"
+        description: "Module Ids to filter by"
+        required: false
+        schema:
+          type: 'string'
       responses:
         "200":
           description: "OK"
@@ -132,30 +134,6 @@ paths:
                 type: "array"
                 items:
                   $ref: '#/components/schemas/Course'
-        "400":
-          description: |
-            Bad Request    
-            types: MalformedLoginToken, MultipleAuthorizationError
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GenericError'
-        "401":
-          description: |
-            Unauthorized  
-            types:  JwtAuthorization, LoginTokenExpired
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GenericError'
-        "422":
-          description: |
-            Unprocessable Entity   
-            types: LoginTokenSignatureInvalid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GenericError'
   /courses/{id}:
     get:
       tags:
@@ -349,6 +327,10 @@ components:
       properties:
         courseId:
           type: string
+        modules:
+          type: array
+          items:
+            $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/exam-reg-management.yaml#/components/schemas/Module'
         courseName:
           type: string
         courseType:

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.11.1"
+  version: "0.12.1"
   title: "UC4"
 
 servers:

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -138,9 +138,6 @@ paths:
     get:
       tags:
       - "Course Management"
-      security:
-        - uc4_token_login: []
-        - uc4_token_login_header: []
       summary: "Find course by course id"
       description: "Find course by course id"
       operationId: "findCourseByCourseId"
@@ -158,34 +155,10 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Course'
-          "400":
-            description: |
-              Bad Request    
-              types: MalformedLoginToken, MultipleAuthorizationError
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/GenericError'
-          "401":
-            description: |
-              Unauthorized  
-              types: JwtAuthorization, LoginTokenExpired
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/GenericError'
           "404":
             description: |
               Not Found  
               types: KeyNotFound
-            content:
-              application/json:
-                schema:
-                  $ref: '#/components/schemas/GenericError'
-          "422":
-            description: |
-              Unprocessable Entity   
-              types: LoginTokenSignatureInvalid
             content:
               application/json:
                 schema:

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -119,9 +119,9 @@ paths:
         required: false
         schema:
           type: 'string'
-      - name: "modules"
+      - name: "moduleIds"
         in: "query"
-        description: "Module Ids to filter by"
+        description: "Comma seperated list of module Ids to filter by"
         required: false
         schema:
           type: 'string'
@@ -300,10 +300,10 @@ components:
       properties:
         courseId:
           type: string
-        modules:
+        moduleIds:
           type: array
           items:
-            $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/exam-reg-management.yaml#/components/schemas/Module'
+            type: string
         courseName:
           type: string
         courseType:

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -125,8 +125,8 @@ paths:
     delete:
       tags:
       - "Examination Regulation Management"
-      summary: "Flag an examination regulations as non-active"
-      description: "Flag an examination regulation as non-active, a change which will be persisted on chain."
+      summary: "Flag an examination regulations as inactive"
+      description: "Flag an examination regulation as inactive, a change which will be persisted on chain."
       operationId: "deleteExaminationRegulation"
       security:
         - uc4_token_login: [] 

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Examination Regulation API for UC4."
-  version: "0.11.1"
+  version: "0.12.1"
   title: "UC4"
 
 servers:

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -48,6 +48,12 @@ paths:
         required: false
         schema:
           type: "string"
+      - name: "active"
+        in: "query"
+        description: "A flag determining, if only active or inactive examination regulations should be fetched"
+        required: false
+        schema:
+          type: "string"
       responses:
         "200":
           description: "OK"
@@ -74,6 +80,12 @@ paths:
         required: false
         schema:
           type: "string"
+      - name: "active"
+        in: "query"
+        description: "A flag determining, if only modules from active or inactive examination regulations should be fetched"
+        required: false
+        schema:
+          type: "string"
       responses:
         "200":
           description: "OK"
@@ -93,6 +105,13 @@ paths:
       summary: "Get all examination regulations"
       description: "Get all examination regulations which were previously used, or are currently used in the system"
       operationId: "getAllExaminationRegulation"
+      parameters:
+      - name: "active"
+        in: "query"
+        description: "A flag determining, if names of active or inactive examination regulations should be fetched"
+        required: false
+        schema:
+          type: "string"
       responses:
         "200":
           description: "OK"

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -66,6 +66,120 @@ paths:
               examples:
                 ConfigurationExample:
                   $ref: '#/components/examples/ExampleExaminationRegulations'
+    post:
+      tags:
+      - "Examination Regulation Management"
+      summary: "Add examination regulations"
+      description: "Add an examination regulation, which will then be stored on the chain."
+      operationId: "addExaminationRegulation"
+      security:
+        - uc4_token_login: [] 
+        - uc4_token_login_header: []
+      responses:
+        "201":
+          description: "Created"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExaminationRegulation'
+              examples:
+                ConfigurationExample:
+                  $ref: '#/components/examples/ExampleExaminationRegulation'
+        "400":
+          description: | 
+            Bad Request  
+            types: MalformedLoginToken, Deserialization, JsonValidation, MultipleAuthorizationError
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
+        "401":
+          description: |
+            Unauthorized  
+            types: JwtAuthorization, LoginTokenExpired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "403":
+          description: |
+            Forbidden  
+            types: NotEnoughPrivileges
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity  
+            types: Validation, ValidationTimeout, LoginTokenSignatureInvalid
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/GenericError'
+                  - $ref: '#/components/schemas/DetailedError'
+  /examination-regulations/{examinationRegulation}:
+    delete:
+      tags:
+      - "Examination Regulation Management"
+      summary: "Flag an examination regulations as non-active"
+      description: "Flag an examination regulation as non-active, a change which will be persisted on chain."
+      operationId: "deleteExaminationRegulation"
+      security:
+        - uc4_token_login: [] 
+        - uc4_token_login_header: []
+      parameters:
+      - in: "path"
+        name: "examinationRegulation"
+        required: true
+        schema: 
+          type: "string"
+      responses:
+        "200":
+          description: "OK"
+        "400":
+          description: |
+            Bad Request    
+            types: MalformedLoginToken, MultipleAuthorizationError
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "401":
+          description: |
+            Unauthorized  
+            types: JwtAuthorization, LoginTokenExpired
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "403":
+          description: |
+            Forbidden  
+            types: NotEnoughPrivileges
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "404":
+          description: |
+            Not Found  
+            types: KeyNotFound
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+        "422":
+          description: |
+            Unprocessable Entity   
+            types: LoginTokenSignatureInvalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
   /examination-regulations/modules:
     get:
       tags:
@@ -180,38 +294,47 @@ components:
         - id: "M.1358.91583"
           name: "Complexity Theory"
     ExampleExaminationRegulations:
-      summary: "An example for the ExaminationRegulation object"
+      summary: "An example for an Array of ExaminationRegulation objects"
       value:
-        - name: "Computer Science v3"
+        - name: "Bachelor Computer Science v3"
           active: true
           modules:
             - id: "M.1275.01158"
               name: "Math 1"
-            - id: "M.1275.56002"
+            - id: "M.1275.01159"
               name: "Math 2"
-            - id: "M.1358.91583"
+            - id: "M.1275.78235"
               name: "Complexity Theory"
-        - name: "Computer Science v4"
-          active: false
+        - name: "Bachelor Computer Science v4"
+          active: true
           modules:
-            - id: "M.1568.98158"
+            - id: "M.1278.15686"
               name: "Math"
-            - id: "M.4186.23588"
-              name: "Secure Software Engineering"
+            - id: "M.1275.78235"
+              name: "Complexity Theory"
+            - id: "M.1278.79512"
+              name: "IT-Security"
+        - name: "Bachelor Philosophy v1"
+          active: true
+          modules:
+            - id: "M.1358.15686"
+              name: "Introduction to Philosophy"
+            - id: "M.1358.15653"
+              name: "Theoretical Philosophy"
+            - id: "M.1358.15418"
+              name: "Applied Ethics"
     ExampleExaminationRegulation:
       summary: "An example for the ExaminationRegulation object"
       value:
-        name: "Computer Science v3"
+        name: "Bachelor Computer Science v3"
+        active: true
         modules:
-          name: "Computer Science v3"
-          modules:
-            - id: "M.1275.01158"
-              name: "Math 1"
-            - id: "M.1275.56002"
-              name: "Math 2"
-            - id: "M.1358.91583"
-              name: "Complexity Theory"
-      
+          - id: "M.1275.01158"
+            name: "Math 1"
+          - id: "M.1275.01159"
+            name: "Math 2"
+          - id: "M.1275.78235"
+            name: "Complexity Theory"
     JsonSemester:
       summary: "An example for the JsonSemester"
       value:

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -97,6 +97,8 @@ components:
       properties:
         name:
           type: string
+        active:
+          type: boolean
         modules:
           type: array
           items:
@@ -138,6 +140,7 @@ components:
       value:
         examinationRegulations: 
           - name: "Computer Science v3"
+            active: true
             modules:
               - id: "M.1275.01158"
                 name: "Math 1"
@@ -146,6 +149,7 @@ components:
               - id: "M.1358.91583"
                 name: "Complexity Theory"
           - name: "Computer Science v4"
+            active: false
             modules:
               - id: "M.1568.98158"
                 name: "Math"

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -1,0 +1,176 @@
+openapi: "3.0.0"
+info:
+  description: "This is the Exam-Reg API for UC4."
+  version: "0.11.1"
+  title: "UC4"
+
+servers:
+  - url: https://uc4.cs.upb.de/api/production/exam-reg-management
+
+tags:
+- name: "Version Management"
+  description: "Everything about the Version"
+  externalDocs:
+    description: "Find out more"
+    url: "https://github.com/upb-uc4"
+- name: "Examination Regulation Management"
+  description: "Everything about the configuration"
+  externalDocs:
+    description: "Find out more"
+    url: "https://github.com/upb-uc4"
+
+paths:
+  /version:
+    get:
+      tags:
+      - "Version Management"
+      summary: "Get version"
+      description: "Returns the version of the current service"
+      operationId: "getVersion"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonVersionNumber'
+  /examination-regulation:
+    get:
+      tags:
+      - "Examination Regulation Management"
+      summary: "Get examination regulations"
+      description: "Get all examination regulations, or the ones specified by the query parameter"
+      operationId: "getExaminationRegulation"
+      parameters:
+      - name: "regulations"
+        in: "query"
+        description: "A comma seperated list of examination regulations to filter by"
+        required: false
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonExaminationRegulations'
+              examples:
+                ConfigurationExample:
+                  $ref: '#/components/examples/ExampleJsonExaminationRegulations'
+  /examination-regulation/names:
+    get:
+      tags:
+      - "Examination Regulation Management"
+      summary: "Get all examination regulations"
+      description: "Get all examination regulations which were previously used, or are currently used in the system"
+      operationId: "getAllExaminationRegulation"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonExamRegNameList'
+              examples:
+                ConfigurationExample:
+                  $ref: '#/components/examples/ExampleJsonExamRegNameList'
+components:
+  securitySchemes:
+    uc4_token_login:
+      type: apiKey
+      in: cookie
+      name: login
+    uc4_token_login_header:
+      type: http
+      scheme: bearer
+  schemas:
+    JsonExamRegNameList:
+      type: "object"
+      properties:
+        examinationRegulations:
+          type: array
+          items:
+            type: string
+    ExaminationRegulation:
+      type: "object"
+      properties:
+        name:
+          type: string
+        modules:
+          type: array
+          items:
+            $ref: '#/components/schemas/Module'
+    Module:
+      type: "object"
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    JsonExaminationRegulations:
+      type: "object"
+      properties:
+        examinationRegulations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExaminationRegulation'
+    JsonVersionNumber:
+      type: object
+      properties:
+        versionNumber:
+          type: string
+    GenericError:
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/GenericError'
+        - type: object
+    DetailedError:
+      allOf:
+        - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/DetailedError'
+        - type: object
+  examples:
+    ExampleJsonExamRegNameList:
+      summary: "An example for the JsonExamRegNameList object"
+      value:
+        examinationRegulations: ["Computer Science v3", "Computer Science v4", "Philosophy"]
+    ExampleJsonExaminationRegulations:
+      summary: "An example for the ExaminationRegulation object"
+      value:
+        examinationRegulations: 
+          - name: "Computer Science v3"
+            modules:
+              - id: "M.1275.01158"
+                name: "Math 1"
+              - id: "M.1275.56002"
+                name: "Math 2"
+              - id: "M.1358.91583"
+                name: "Complexity Theory"
+          - name: "Computer Science v4"
+            modules:
+              - id: "M.1568.98158"
+                name: "Math"
+              - id: "M.4186.23588"
+                name: "Secure Software Engineering"
+        
+    ExampleExaminationRegulation:
+      summary: "An example for the ExaminationRegulation object"
+      value:
+        name: "Computer Science v3"
+        modules:
+          name: "Computer Science v3"
+          modules:
+            - id: "M.1275.01158"
+              name: "Math 1"
+            - id: "M.1275.56002"
+              name: "Math 2"
+            - id: "M.1358.91583"
+              name: "Complexity Theory"
+      
+    JsonSemester:
+      summary: "An example for the JsonSemester"
+      value:
+        semester: "SS2020"
+        
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io" 

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -134,6 +134,7 @@ paths:
       parameters:
       - in: "path"
         name: "examinationRegulation"
+        description: "The name of the examination regulation which should be flagged as inactive."
         required: true
         schema: 
           type: "string"

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -60,6 +60,32 @@ paths:
               examples:
                 ConfigurationExample:
                   $ref: '#/components/examples/ExampleExaminationRegulations'
+  /examination-regulations/modules:
+    get:
+      tags:
+      - "Examination Regulation Management"
+      summary: "Get all examination regulations"
+      description: "Get all examination regulations which were previously used, or are currently used in the system"
+      operationId: "getModules"
+      parameters:
+      - name: "moduleIds"
+        in: "query"
+        description: "A comma seperated list of moduleIds to filter by"
+        required: false
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  type: string
+              examples:
+                ModuleIds:
+                  $ref: '#/components/examples/ExampleModuleList'
   /examination-regulations/names:
     get:
       tags:
@@ -77,7 +103,7 @@ paths:
                 items:
                   type: string
               examples:
-                ConfigurationExample:
+                ExamRegNameList:
                   $ref: '#/components/examples/ExampleExamRegNameList'
 components:
   securitySchemes:
@@ -122,9 +148,18 @@ components:
         - type: object
   examples:
     ExampleExamRegNameList:
-      summary: "An example for the JsonExamRegNameList object"
+      summary: "An example for a list of examination regulation names"
       value:
         ["Computer Science v3", "Computer Science v4", "Philosophy"]
+    ExampleModuleList:
+      summary: "An example for a list of modules"
+      value:
+        - id: "M.1275.01158"
+          name: "Math 1"
+        - id: "M.1275.56002"
+          name: "Math 2"
+        - id: "M.1358.91583"
+          name: "Complexity Theory"
     ExampleExaminationRegulations:
       summary: "An example for the ExaminationRegulation object"
       value:

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -70,8 +70,8 @@ paths:
     get:
       tags:
       - "Examination Regulation Management"
-      summary: "Get all examination regulations"
-      description: "Get all examination regulations which were previously used, or are currently used in the system"
+      summary: "Get all modules of examination regulations"
+      description: "Get all modules which exist in any examination regulations which were previously used, or are currently used in the system. Can be further specified by query parameters."
       operationId: "getModules"
       parameters:
       - name: "moduleIds"
@@ -102,8 +102,8 @@ paths:
     get:
       tags:
       - "Examination Regulation Management"
-      summary: "Get all examination regulations"
-      description: "Get all examination regulations which were previously used, or are currently used in the system"
+      summary: "Get all examination regulations' names"
+      description: "Get all names of any examination regulations which were previously used, or are currently used in the system. Can be further specified by query parameters."
       operationId: "getAllExaminationRegulation"
       parameters:
       - name: "active"

--- a/exam-reg-management.yaml
+++ b/exam-reg-management.yaml
@@ -1,11 +1,11 @@
 openapi: "3.0.0"
 info:
-  description: "This is the Exam-Reg API for UC4."
+  description: "This is the Examination Regulation API for UC4."
   version: "0.11.1"
   title: "UC4"
 
 servers:
-  - url: https://uc4.cs.upb.de/api/production/exam-reg-management
+  - url: https://uc4.cs.upb.de/api/production/examreg-management
 
 tags:
 - name: "Version Management"
@@ -34,7 +34,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JsonVersionNumber'
-  /examination-regulation:
+  /examination-regulations:
     get:
       tags:
       - "Examination Regulation Management"
@@ -54,11 +54,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsonExaminationRegulations'
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/ExaminationRegulation'
               examples:
                 ConfigurationExample:
-                  $ref: '#/components/examples/ExampleJsonExaminationRegulations'
-  /examination-regulation/names:
+                  $ref: '#/components/examples/ExampleExaminationRegulations'
+  /examination-regulations/names:
     get:
       tags:
       - "Examination Regulation Management"
@@ -71,10 +73,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsonExamRegNameList'
+                type: "array"
+                items:
+                  type: string
               examples:
                 ConfigurationExample:
-                  $ref: '#/components/examples/ExampleJsonExamRegNameList'
+                  $ref: '#/components/examples/ExampleExamRegNameList'
 components:
   securitySchemes:
     uc4_token_login:
@@ -85,13 +89,6 @@ components:
       type: http
       scheme: bearer
   schemas:
-    JsonExamRegNameList:
-      type: "object"
-      properties:
-        examinationRegulations:
-          type: array
-          items:
-            type: string
     ExaminationRegulation:
       type: "object"
       properties:
@@ -110,13 +107,6 @@ components:
           type: string
         name:
           type: string
-    JsonExaminationRegulations:
-      type: "object"
-      properties:
-        examinationRegulations:
-          type: array
-          items:
-            $ref: '#/components/schemas/ExaminationRegulation'
     JsonVersionNumber:
       type: object
       properties:
@@ -131,31 +121,29 @@ components:
         - $ref: 'https://raw.githubusercontent.com/upb-uc4/api/develop/errors.yaml#/components/schemas/DetailedError'
         - type: object
   examples:
-    ExampleJsonExamRegNameList:
+    ExampleExamRegNameList:
       summary: "An example for the JsonExamRegNameList object"
       value:
-        examinationRegulations: ["Computer Science v3", "Computer Science v4", "Philosophy"]
-    ExampleJsonExaminationRegulations:
+        ["Computer Science v3", "Computer Science v4", "Philosophy"]
+    ExampleExaminationRegulations:
       summary: "An example for the ExaminationRegulation object"
       value:
-        examinationRegulations: 
-          - name: "Computer Science v3"
-            active: true
-            modules:
-              - id: "M.1275.01158"
-                name: "Math 1"
-              - id: "M.1275.56002"
-                name: "Math 2"
-              - id: "M.1358.91583"
-                name: "Complexity Theory"
-          - name: "Computer Science v4"
-            active: false
-            modules:
-              - id: "M.1568.98158"
-                name: "Math"
-              - id: "M.4186.23588"
-                name: "Secure Software Engineering"
-        
+        - name: "Computer Science v3"
+          active: true
+          modules:
+            - id: "M.1275.01158"
+              name: "Math 1"
+            - id: "M.1275.56002"
+              name: "Math 2"
+            - id: "M.1358.91583"
+              name: "Complexity Theory"
+        - name: "Computer Science v4"
+          active: false
+          modules:
+            - id: "M.1568.98158"
+              name: "Math"
+            - id: "M.4186.23588"
+              name: "Secure Software Engineering"
     ExampleExaminationRegulation:
       summary: "An example for the ExaminationRegulation object"
       value:
@@ -174,7 +162,6 @@ components:
       summary: "An example for the JsonSemester"
       value:
         semester: "SS2020"
-        
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io" 

--- a/validation/lagom-validation/course-management.md
+++ b/validation/lagom-validation/course-management.md
@@ -8,7 +8,7 @@ Not validated, as it is a generated UUID.
 ### courseName (String)
 - vCourseName1: courseName.length ∈ [1, 100]
 - iCourseName1: courseName is the empty String
-- iCourseName2: courseName.length ∉ 100
+- iCourseName2: courseName.length > 100
 
 ### courseType (String)
 *validCourseTypes* := {"Lecture", "Seminar", "Project Group"}

--- a/validation/lagom-validation/examreg-management.md
+++ b/validation/lagom-validation/examreg-management.md
@@ -25,4 +25,4 @@
 ### modules (Array[Modules])
 - vModule1: At least one Module exists and all Modules are valid as defined in [Module](#Module)
 - iModule1: The Array is empty
-- iModule2: At one Module exists that is invalid as in the definition in [Module](#Module)
+- iModule2: At least one Module exists that is invalid as in the definition in [Module](#Module)

--- a/validation/lagom-validation/examreg-management.md
+++ b/validation/lagom-validation/examreg-management.md
@@ -1,0 +1,28 @@
+# Examination Regulation Validation
+
+##  <a id="Module" /> Module
+### id (String)
+- vId1: id.length ∈ [1, 20]
+- iId1: id is the empty String
+- iId2: id.length > 20
+
+### name (String)
+- vName1: name.length ∈ [1, 100]
+- iName1: name is the empty String
+- iName2: name.length > 100
+
+## Examination Regulation
+
+### name (String)
+- vName1: name.length ∈ [1, 100]
+- iName1: name is the empty String
+- iName2: name.length > 100
+
+### active (Boolean)
+- vActive1: active = true
+- iActive1: active = false
+
+### modules (Array[Modules])
+- vModule1: At least one Module exists and all Modules are valid as defined in [Module](#Module)
+- iModule1: The Array is empty
+- iModule2: At one Module exists that is invalid as in the definition in [Module](#Module)


### PR DESCRIPTION
### Reason for this PR
- Examination Regulations are needed for both enrollment and examination, our next major milestones

### Changes in this PR
- Added exam-reg-management.yaml, describing examination-regulation service, with endpoints for:
  - Fetching list of names of all examination regulations
  - Fetching list of examination regulations, with query parameter
- Removed security from "GetAllCourses" call
- Added query parameter for modules to "GetAllCourses"