### PR TITLE
add documentation on input checks for hlf contracts

### DIFF
--- a/hlf/chaincode/approval.md
+++ b/hlf/chaincode/approval.md
@@ -27,7 +27,9 @@ The Errors returned are defined [here](errors.md#Errors).
         ]
       }
       ```
-       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.
+       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
+       For detailed informations see [Input Checks](#Checks).
+
 
 ### GetApprovals
 - ID = getApprovals
@@ -53,7 +55,31 @@ The Errors returned are defined [here](errors.md#Errors).
       ```
       - Description: This error is returned, if the state of data on the ledger is not consistent with the current model. This error should only occur if the model changes while the old ledger state remains without modification.
 
+    - [DetailedError](errors.md#DetailedError) 
+      ```json
+      {
+        "type": "HLUnprocessableEntity",
+        "title": "The following parameters do not conform to the specified format",
+        "invalidParams": [
+          {
+            "name": "string",
+            "reason": "string"
+          }
+        ]
+      }
+      ```
+       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
+       For detailed informations see [Input Checks](#Checks).
+
 
 ## <a id="Models" />Models
 
 - None
+
+## <a id="Checks" />Input Checks
+
+
+- **contractName**
+  - Check, if not null or an empty String.
+- **transactionName**
+  - Check, if not null or an empty String.

--- a/hlf/chaincode/certificate.md
+++ b/hlf/chaincode/certificate.md
@@ -28,7 +28,8 @@ The Errors returned are defined [here](errors.md#Errors).
         ]
       }
       ```
-       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.
+       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
+       For detailed informations see [Input Checks](#Checks).
 
     - [GenericError](errors.md#GenericError) 
       ```json
@@ -37,7 +38,8 @@ The Errors returned are defined [here](errors.md#Errors).
         "title": "There is already a certificate for the given enrollmentId",
       }
       ```
-    - Description: This error is returned, if a certificate for the given enrollmentId is already present on the ledger.
+      - Description: This error is returned, if a certificate for the given enrollmentId is already present on the ledger.
+
 
 ### Update Certificate
 - ID = updateCertificate
@@ -70,7 +72,8 @@ The Errors returned are defined [here](errors.md#Errors).
         ]
       }
       ```
-      - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.
+      - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
+      For detailed informations see [Input Checks](#Checks).
 
 ### Get Certificate
 - ID = getCertificate
@@ -95,7 +98,30 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
       - Description: This error is returned, if the state of data on the ledger is not consistent with the curent model. This error should only occurr if the model changes while the old ledger state remains without modification.
-    - 
+    
+    - [DetailedError](errors.md#DetailedError) 
+      ```json
+      {
+        "type": "HLUnprocessableEntity",
+        "title": "The following parameters do not conform to the specified format",
+        "invalidParams": [
+          {
+            "name": "string",
+            "reason": "string"
+          }
+        ]
+      }
+      ```
+      - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
+      For detailed informations see [Input Checks](#Checks).
+
+
 ## <a id="Models" />Models
 
 - None
+
+## <a id="Checks" />Input Checks
+  - **enrollmentId**
+    - Check, if not null or an empty String.
+  - **certificate**
+    - Check, if not null or an empty String.

--- a/hlf/chaincode/examination-regulation.md
+++ b/hlf/chaincode/examination-regulation.md
@@ -29,13 +29,13 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
        - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.
-       - modules with the same id must always have the same name
+       For detailed informations see [examinationRegulation checks](#examinationRegulationChecks).
        
     - [GenericError](errors.md#GenericError) 
       ```json
       {
         "type": "HLConflict",
-        "title": "There is already an ExaminationRegulation for the given name",
+        "title": "There is already an ExaminationRegulation for the given name"
       }
       ```
     - Description: This error is returned, if an examination regulation with the given name is already present on the ledger.
@@ -106,3 +106,21 @@ The Errors returned are defined [here](errors.md#Errors).
   "name": "Math 1"
 }
 ```
+
+## <a id="Checks" />Input Checks
+### <a id="examinationRegaultaionChecks" />examinationRegulation
+- Checks, if parseable Json.
+- **name**
+  - Check, if not null or an empty String.
+- **modules**
+  - see [modules](#moduleChecks)
+
+
+### <a id="modulesChecks" />modules
+- Check, if not null or an empty list.
+- **id**
+  - Check, if not null or an empty String.
+  - Check for duplicate entries.
+  - Check inconsistent entries (i.e. id was used before with different name)
+- **name**
+  - Check, if not null or an empty string.

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -191,5 +191,5 @@ This method adds a single entry to the list of semesters in the MatriculationDat
   - Check for duplicate entries.
 - **semesters**
   - Check, if not null or an empty list.
-  - Check, if containing strings are in the format (WS\d{4}/\d{2}|SS\d{4})
+  - Check, if containing strings are in the format (WS\d{4}/\d{2}|SS\d{4}), e.g. WS2020/21 or SS2020. Also, in case of winter semester, check, if the two included years are two consecutive years with the full displayed year being the chronologically earlier one.
   - Check for duplicate entries.

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -135,7 +135,8 @@ This method adds a single entry to the list of semesters in the MatriculationDat
       }
       ```
       - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.
-      For detailed informations see [subjectMatriculation checks](#subjectMatriculationCecks).
+      For detailed informations see [subjectMatriculation checks](#subjectMatriculationChecks).
+
     
     - [GenericError](errors.md#GenericError) 
       ```json

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -27,7 +27,8 @@ The Errors returned are defined [here](errors.md#Errors).
         ]
       }
       ```
-       - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.
+       - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
+       For detailed informations see [matriculationData checks](#matriculationDataCecks).
 
 
     - [GenericError](errors.md#GenericError) 
@@ -38,6 +39,8 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
     - Description: This error is returned, if a matriculation data with the given enrollmentId is already present on the ledger.
+
+
 
 ### Update Matriculation Data
 - ID = updateMatriculationData
@@ -69,7 +72,8 @@ The Errors returned are defined [here](errors.md#Errors).
         ]
       }
       ```
-      - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.
+      - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
+      For detailed informations see [matriculationData checks](#matriculationDataCecks).
 
 ### Get Matriculation Data
 - ID = getMatriculationData
@@ -130,6 +134,7 @@ This method adds a single entry to the list of semesters in the MatriculationDat
       }
       ```
       - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.
+      For detailed informations see [subjectMatriculation checks](#subjectMatriculationCecks).
     
     - [GenericError](errors.md#GenericError) 
       ```json
@@ -166,3 +171,22 @@ This method adds a single entry to the list of semesters in the MatriculationDat
   "semesters": ["WS2019/20", "SS2020"]
 }
 ```
+
+## <a id="Checks" />Input Checks
+### <a id="matriculationDataChecks" />matriculationData
+- Checks, if parseable Json.
+- **enrollmentId**
+  - Check, if not null or an empty String.
+- **matriculationStatus**
+  - see [subjectMatriculation](#subjectMatriculationChecks)
+
+
+### <a id="subjectMatriculationChecks" />subjectMatriculation
+- Check, if not null or an empty list.
+- **fieldOfStudy**
+  - Check, if not null or an empty String.
+  - Check for duplicate entries.
+- **semesters**
+  - Check, if not null or an empty list.
+  - Check, if containing strings are in the format (WS\d{4}/\d{2}|SS\d{4})
+  - Check for duplicate entries.

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -28,7 +28,8 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
        - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
-       For detailed informations see [matriculationData checks](#matriculationDataCecks).
+       For detailed informations see [matriculationData checks](#matriculationDataChecks).
+
 
 
     - [GenericError](errors.md#GenericError) 

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -74,7 +74,8 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
       - Description: This error is returned, if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
-      For detailed informations see [matriculationData checks](#matriculationDataCecks).
+      For detailed informations see [matriculationData checks](#matriculationDataChecks).
+
 
 ### Get Matriculation Data
 - ID = getMatriculationData


### PR DESCRIPTION
*** Reason for this PR ***
For better understanding on valid inputs, checks, which are performed on inputs, need to be documented.

*** Changes in this PR ***
Added listing of the method parameters which are checked as well as a short description of the corresponding checks in the according markdown document of each contract.