### PR TITLE
Add ProposalData model

### DIFF
--- a/hlf/chaincode/approval.md
+++ b/hlf/chaincode/approval.md
@@ -9,7 +9,9 @@ The Errors returned are defined [here](errors.md#Errors).
 ### ApproveTransaction
 - ID = approveTransaction
 - Send
-    - contractName, transactionName, param1, ..., paramN :: String
+    - userId :: String
+    - signature :: String
+    - proposalData :: [ProposalData](#ProposalData)
 - Receive
     - approvals :: List\<String\>
       -  Description: Success, returns the list of approvals.
@@ -74,7 +76,17 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ## <a id="Models" />Models
 
-- None
+### <a id="ProposalData" />ProposalData
+```json
+{
+  "contractName": "UC4.Certificate",
+  "transactionName": "addCertificate",
+  "params": [
+    "007",
+    "legit certificate"
+  ]
+}
+```
 
 ## <a id="Checks" />Input Checks
 

--- a/hlf/chaincode/approval.md
+++ b/hlf/chaincode/approval.md
@@ -36,7 +36,7 @@ The Errors returned are defined [here](errors.md#Errors).
 ### GetApprovals
 - ID = getApprovals
 - Send
-    - contractName, transactionName, param1, ..., paramN :: String
+    - proposalData :: [ProposalData](#ProposalData)
 - Receive
     - approvals :: List\<String\>
 


### PR DESCRIPTION
### Reason for this PR:
- hyperledger does not like pushing proposals signed by one user through another user's connection, meaning we will have to redesign our approval contract

### Changes in this PR:
- group ```contractName```, ```transactionName```, and transaction parameters in one proposal-data json object
- change signature of ```approveTransaction``` to take userId, signature, and proposal data