### PR TITLE
Remove fields of study from configuration object

### DIFF
--- a/configuration-management.yaml
+++ b/configuration-management.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "This is the Configuration API for UC4."
-  version: "0.12.1"
+  version: "0.13.1"
   title: "UC4"
 
 servers:
@@ -131,10 +131,6 @@ components:
     Configuration:
       type: "object"
       properties:
-        fieldsOfStudy:
-          type: array
-          items:
-            type: string
         countries:
           type: array
           items:
@@ -252,7 +248,7 @@ components:
         chaincodeVersion: "v0.10.0"
         networkVersion: "v0.10.0"
     ExampleHyperledgerVersionsUnavailable:
-      summary: "An example for the HyperledgerVersions object, with an unavailabe version"
+      summary: "An example for the HyperledgerVersions object, with an unavailable version"
       value:
         apiVersion: "v0.10.0"
         chaincodeVersion: "v0.10.0"
@@ -260,7 +256,6 @@ components:
     ExampleConfiguration:
       summary: "An example for the configuration"
       value:
-        fieldsOfStudy: ["Computer Science", "Philosophy", "Media Sciences", "Economics", "Mathematics", "Physics", "Chemistry", "Education", "Sports Science", "Japanology", "Spanish Culture", "Pedagogy", "Business Informatics", "Linguistics"]
         countries: ["Germany", "United States", "Italy", "France", "United Kingdom", "Belgium", "Netherlands", "Spain", "Austria", "Switzerland", "Poland"]
         languages: ["German", "English"]
         courseTypes: ["Lecture", "Seminar", "Project Group"]

--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -42,15 +42,15 @@ paths:
         - uc4_token_login: [] 
         - uc4_token_login_header: []
       requestBody:
-        description: "PostMessageMatriculationData, containing the semester the student want to be enrolled in, and the corresponding fieldOfStudy."
+        description: "PutMessageMatriculation, containing the semester the student want to be enrolled in, and the corresponding fieldOfStudy."
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PostMessageMatriculation'
+              $ref: '#/components/schemas/PutMessageMatriculation'
             examples:
               PostMessageMatriculation:
-                $ref: '#/components/examples/ExamplePostMessageMatriculation'
+                $ref: '#/components/examples/ExamplePutMessageMatriculation'
       parameters:
       - in: "path"
         name: "username"
@@ -323,13 +323,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SubjectMatriculation'
-    PostMessageMatriculation:
-      type: "object"
-      properties:
-        matriculation:
-          type: array
-          items:
-            $ref: '#/components/schemas/SubjectMatriculation'
     UnsignedProposalAddEntry:
       type: "object"
       properties:
@@ -358,7 +351,6 @@ components:
       properties:
         fieldOfStudy:
           type: string
-          enum: ["Computer Science", "Philosophy","Media Sciences","Economics","Mathematics","Physics","Chemistry","Education","Sports Science","Japanology","Spanish Culture","Pedagogy","Business Informatics","Linguistics"]
         semesters:
           type: array
           items:
@@ -381,20 +373,10 @@ components:
       summary: "Example for PutMessageMatriculation"
       value:
         matriculation:
-          - fieldOfStudy: "Computer Science"
+          - fieldOfStudy: "Bachelor Computer Science v4"
             semesters:
               - "SS2020"
-          - fieldOfStudy: "Philosophy"
-            semesters: 
-              - "SS2020"
-    ExamplePostMessageMatriculation:
-      summary: "Example for PostMessageMatriculation"
-      value:
-        matriculation:
-          - fieldOfStudy: "Computer Science"
-            semesters:
-              - "SS2020"
-          - fieldOfStudy: "Philosophy"
+          - fieldOfStudy: "Bachelor Philosophy v1"
             semesters: 
               - "SS2020"
     ExampleUnsignedProposalAddEntry:

--- a/validation/lagom-validation/matriculation-management.md
+++ b/validation/lagom-validation/matriculation-management.md
@@ -3,7 +3,7 @@
 ## SubjectMatriculation
 
 ### fieldOfStudy (String)
-*validFieldsOfStudies* := {"Computer Science", "Philosophy", "Media Sciences", "Economics", "Mathematics", "Physics","Chemistry", "Education", "Sports Science", "Japanology", "Spanish Culture", "Pedagogy", "Business Informatics", "Linguistics"}
+*validFieldsOfStudies* are names of active examination regulations
 - vFieldOfStudy1: fieldOfStudy ∈ *validFieldsOfStudies*
 - vFieldOfStudy1: fieldOfStudy ∉ *validFieldsOfStudies*
 


### PR DESCRIPTION
### Reason for this PR
- As we want to use proper examination regulation names now, the fields of study are not hardcoded anymore and cannot be fetched from the configuration service

### Changes in this PR
- Removed fields of study from configuration object and example
- Adjusted validation document of the matriculation service, as the fields of studies are now defined by the examination regulation service
- Removed field of study enum from matriculation management API 
- Removed PostMessageMatriculation from API as it does not exist