### PR TITLE
Fix api url being incorrect in 5 api definitions

### DIFF
--- a/admission-management.yaml
+++ b/admission-management.yaml
@@ -1,11 +1,13 @@
 openapi: "3.0.0"
 info:
   description: "This is the Admission API for UC4."
-  version: "0.13.1"
+  version: "0.15.1"
   title: "UC4"
 
 servers:
-  - url: https://uc4.cs.upb.de/api/admission-management
+  - url: https://uc4.cs.upb.de/api/experimental/admission-management
+  - url: https://uc4.cs.upb.de/api/develop/admission-management
+  - url: https://uc4.cs.upb.de/api/production/admission-management
 
 tags:
 - name: "Version Management"

--- a/authentication-management.yaml
+++ b/authentication-management.yaml
@@ -1,10 +1,14 @@
 openapi: "3.0.0"
 info:
   description: "This is the Authentication API for UC4."
-  version: "0.8.2"
+  version: "0.15.1"
   title: "UC4"
+  
 servers:
-  - url: https://uc4.cs.upb.de/api/authentication-management
+  - url: https://uc4.cs.upb.de/api/experimental/authentication-management
+  - url: https://uc4.cs.upb.de/api/develop/authentication-management
+  - url: https://uc4.cs.upb.de/api/production/authentication-management
+  
 tags:
 - name: "Version Management"
   description: "Everything about the Version"

--- a/certificate-management.yaml
+++ b/certificate-management.yaml
@@ -1,10 +1,12 @@
 openapi: "3.0.0"
 info:
   description: "This is the Certificate API for UC4."
-  version: "0.10.1"
+  version: "0.15.1"
   title: "UC4"
 
 servers:
+  - url: https://uc4.cs.upb.de/api/experimental/certificate-management
+  - url: https://uc4.cs.upb.de/api/develop/certificate-management
   - url: https://uc4.cs.upb.de/api/production/certificate-management
 
 tags:

--- a/configuration-management.yaml
+++ b/configuration-management.yaml
@@ -1,10 +1,12 @@
 openapi: "3.0.0"
 info:
   description: "This is the Configuration API for UC4."
-  version: "0.14.1"
+  version: "0.15.1"
   title: "UC4"
 
 servers:
+  - url: https://uc4.cs.upb.de/api/experimental/configuration-management
+  - url: https://uc4.cs.upb.de/api/develop/configuration-management
   - url: https://uc4.cs.upb.de/api/production/configuration-management
 
 tags:

--- a/course-management.yaml
+++ b/course-management.yaml
@@ -1,11 +1,13 @@
 openapi: "3.0.0"
 info:
   description: "This is the Course API for UC4."
-  version: "0.12.1"
+  version: "0.15.1"
   title: "UC4"
 
 servers:
-  - url: https://uc4.cs.upb.de/api/course-management
+  - url: https://uc4.cs.upb.de/api/experimental/course-management
+  - url: https://uc4.cs.upb.de/api/develop/course-management
+  - url: https://uc4.cs.upb.de/api/production/course-management
 
 tags:
 - name: "Version Management"

--- a/examreg-management.yaml
+++ b/examreg-management.yaml
@@ -1,10 +1,12 @@
 openapi: "3.0.0"
 info:
   description: "This is the Examination Regulation API for UC4."
-  version: "0.12.1"
+  version: "0.15.1"
   title: "UC4"
 
 servers:
+  - url: https://uc4.cs.upb.de/api/experimental/examreg-management
+  - url: https://uc4.cs.upb.de/api/develop/examreg-management
   - url: https://uc4.cs.upb.de/api/production/examreg-management
 
 tags:

--- a/matriculation-management.yaml
+++ b/matriculation-management.yaml
@@ -1,10 +1,14 @@
 openapi: "3.0.0"
 info:
   description: "This is the Matriculation API for UC4."
-  version: "0.13.2"
+  version: "0.15.1"
   title: "UC4"
+  
 servers:
-  - url: https://uc4.cs.upb.de/api/matriculation-management
+  - url: https://uc4.cs.upb.de/api/experimental/matriculation-management
+  - url: https://uc4.cs.upb.de/api/develop/matriculation-management
+  - url: https://uc4.cs.upb.de/api/production/matriculation-management
+  
 tags:
 - name: "Version Management"
   description: "Everything about the Version"

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -1,10 +1,14 @@
 openapi: "3.0.0"
 info:
   description: "This is the User API for UC4."
-  version: "0.13.1"
+  version: "0.15.1"
   title: "UC4"
+  
 servers:
-  - url: https://uc4.cs.upb.de/api/user-management
+  - url: https://uc4.cs.upb.de/api/experimental/user-management
+  - url: https://uc4.cs.upb.de/api/develop/user-management
+  - url: https://uc4.cs.upb.de/api/production/user-management
+      
 tags:
 - name: "Version Management"
   description: "Everything about the Version"


### PR DESCRIPTION
### Reason for this PR
- All of the api urls given in the api documentation were incomplete, most simply incorrect

### Changes in this PR
- Fixed 5 out of 8 url endpoints not being urls of actually existing endpoints
- Added experimental, develop and production urls to all apis