### PR TITLE
Add new error, for when wrong number of parameters is received

### DIFF
--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -16,6 +16,15 @@ The Errors returned are defined [here](errors.md#Errors).
     - operationData :: [OperationData](#OperationData) 
       -  Description: Success, returns the list of approvals.
 
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLParameterNumberError",
+        "title": "The given number of parameters does not match the required number of parameters for the specified transaction"
+      }
+      ```
+       - Description: This error is returned, if the given number of parameters for the specified transaction does not match the number of required parameters.
+
     - [DetailedError](errors.md#DetailedError) 
       ```json
       {

--- a/hlf/scala/operation.md
+++ b/hlf/scala/operation.md
@@ -14,6 +14,9 @@ Additionally, as described in [General Communication](general-communication.md),
 - Returns
     - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
         - => Success
+    - TransactionError :: Json (refer to: [GenericError](../chaincode/errors.md#GenericError))
+        - => error is returned
+          - If the number of given parameters differs from expected.
     - TransactionError :: Json (refer to: [DetailedError](../chaincode/errors.md#DetailedError))
         - => error is returned
           - If the given parameters could not be parsed.


### PR DESCRIPTION
### Reason for this PR
- If the number of parameters in a TransactionInfo object is incorrect, a new error has to be returned

### Changes in this PR
- Added a new error for when the given number of parameters for the specified transaction does not match the number of required parameters