### PR TITLE
refactor/move_frontend_signing into develop

### DIFF
--- a/hlf/chaincode/access-rights.md
+++ b/hlf/chaincode/access-rights.md
@@ -1,0 +1,5 @@
+# General Access Rights
+
+Every transaction can only be executed by the system admin, unless stated otherwise.
+The system admin is identified by being in the group "System".
+

--- a/hlf/chaincode/admission.md
+++ b/hlf/chaincode/admission.md
@@ -10,6 +10,11 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### Add Admission
 - ID = addAdmission
+- Required Approvals
+  - Users
+    - jsonAdmission.enrollmentId
+  - Groups
+    - System
 - Send
     - jsonAdmission :: [Admission](#Admission)
 - Receive
@@ -46,6 +51,11 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### Drop Admission
 - ID = dropAdmission
+- Required Approvals
+  - Users
+    - related enrollmentId
+  - Groups
+    - System
 - Send
     - admissionId :: String
 - Receive

--- a/hlf/chaincode/group.md
+++ b/hlf/chaincode/group.md
@@ -10,6 +10,9 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### Add User To Group
 - ID = addUserToGroup
+- Required Approvals
+  - Users
+    - lagom-scala-admin-org1 (environment variable)
 - Send
     - enrollmentId :: String
     - groupId :: String

--- a/hlf/chaincode/group.md
+++ b/hlf/chaincode/group.md
@@ -12,7 +12,7 @@ The Errors returned are defined [here](errors.md#Errors).
 - ID = addUserToGroup
 - Required Approvals
   - Users
-    - lagom-scala-admin-org1 (environment variable)
+    - lagom-scala-admin-org1 (hyperledger attr. (set when enrolling))
 - Send
     - enrollmentId :: String
     - groupId :: String

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -8,6 +8,12 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### Add Matriculation Data
 - ID = addMatriculationData
+- Required Approvals
+  - Users
+    - matriculationData.enrollmentId
+  - Groups
+    - Admin
+    - System
 - Send
     - matriculationData :: [MatriculationData](#MatriculationData)
 - Receive
@@ -106,6 +112,12 @@ The Errors returned are defined [here](errors.md#Errors).
 This method adds a single entry to the list of semesters in the MatriculationData, to provide secure updates.
 
 - ID = addEntriesToMatriculationData
+- Required Approvals
+  - Users
+    - enrollmentId
+  - Groups
+    - Admin
+    - System
 - Send
     - enrollmentId :: String
     - matriculation :: List\<[SubjectMatriculation](#SubjectMatriculation)\>

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -124,7 +124,7 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### <a id="OperationData" />OperationData
 The operationId in OperationData is constructed as follows:  
-operationId = String(Base64(SHA256($contractName:$transactionName:$parameters))) 
+operationId = String(Base64(SHA256($contractName:$transactionName:$parameters))) // parameters is stripped of all spaces (replace(" ", ""))
 
 with the String given to the hash function being UTF8 encoded.
 ```json

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -124,7 +124,8 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### <a id="OperationData" />OperationData
 The operationId in OperationData is constructed as follows:  
-operationId = String(Base64(SHA256($contractName:$transactionName:$parameters))) // parameters is stripped of all spaces (replace(" ", ""))
+operationId = String(Base64Url(SHA256($contractName:$transactionName:$parameters))) // parameters is stripped of all spaces (replace(" ", ""))
+
 
 with the String given to the hash function being UTF8 encoded.
 ```json

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -108,12 +108,15 @@ The Errors returned are defined [here](errors.md#Errors).
     - existingEnrollmentId :: String (optional)
     - missingEnrollmentId :: String (optional)
     - initiatorEnrollmentId :: String (optional)
-    - state :: String (optional)
+    - involvedEnrollmentId :: String (optional)
+    - state :: List\<String\> (optional)
 - Receive
     - operationsList :: List\<[OperationData](#OperationData)\>
       - Description: Returns the full list of existing Operations matching the filter parameters.
         All filters are applied consecutively (logical AND).
-        If these parameters are empty, the exhaustive list of all existing Operations is returned.
+      - If all these parameters are empty, the exhaustive list of all existing Operations is returned.
+      - "involvedEnrollmentId" represents an OR-Filter for existing-/missing-/initiator-enrollmentId
+      - List parameters are also a logical OR over all their entries
 
 ## <a id="Models" />Models
 

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -7,7 +7,8 @@ The Errors returned are defined [here](errors.md#Errors).
 ## Transactions
 
 ### ProposeTransaction
-- ID = approveTransaction
+- ID = proposeTransaction
+
 - Send
     - initiator :: String (enrollmentId)
     - contractName, transactionName :: String

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -6,12 +6,13 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ## Transactions
 
-### ProposeTransaction
-- ID = proposeTransaction
+### InitiateOperation
+- ID = initiateOperation
 
 - Send
     - initiator :: String (enrollmentId)
-    - contractName, transactionName :: String
+    - contractName :: String
+    - transactionName :: String
     - params :: List\<String\>
 
 - Receive

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -122,7 +122,8 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ### <a id="OperationData" />OperationData
 The operationId in OperationData is constructed as follows:  
-operationId = SHA256($contractName:$transactionName:$parameters)  
+operationId = String(Base64(SHA256($contractName:$transactionName:$parameters))) 
+
 with the String given to the hash function being UTF8 encoded.
 ```json
 {

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -6,9 +6,10 @@ The Errors returned are defined [here](errors.md#Errors).
 
 ## Transactions
 
-### ApproveTransaction
+### ProposeTransaction
 - ID = approveTransaction
 - Send
+    - initiator :: String (enrollmentId)
     - contractName, transactionName :: String
     - params :: List\<String\>
 
@@ -32,8 +33,33 @@ The Errors returned are defined [here](errors.md#Errors).
        - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
        For detailed informations see [Input Checks](#Checks).
 
-### RejectTransaction
-- ID = rejectTransaction
+### ApproveOperation
+- ID = approveOperation
+- Send
+    - operationId :: String
+
+- Receive
+    - operationData :: [OperationData](#OperationData) 
+      -  Description: Success, returns the list of approvals.
+
+    - [DetailedError](errors.md#DetailedError) 
+      ```json
+      {
+        "type": "HLUnprocessableEntity",
+        "title": "The following parameters do not conform to the specified format",
+        "invalidParams": [
+          {
+            "name": "string",
+            "reason": "string"
+          }
+        ]
+      }
+      ```
+       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
+       For detailed informations see [Input Checks](#Checks).
+
+### RejectOperation
+- ID = rejectOperation
 - Send
     - operationId :: String
     - rejectMessage :: String
@@ -75,50 +101,10 @@ The Errors returned are defined [here](errors.md#Errors).
        - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
        For detailed informations see [Input Checks](#Checks).
 
-
-### GetOperationData
-- ID = getOperationData
-- Send
-    - operationId :: String
-- Receive
-    - operationData :: [OperationData](#OperationData)
-
-- [GenericError](errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLNotFound",
-        "title": "There is no Operation for the given operationId"
-      }
-      ```
-      - Description: This error is returned, if there is no operation for the specified operationId present on the ledger.
-    - [GenericError](errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLUnprocessableLedgerState",
-        "title": "The state on the ledger does not conform to the specified format"
-      }
-      ```
-      - Description: This error is returned, if the state of data on the ledger is not consistent with the current model. This error should only occur if the model changes while the old ledger state remains without modification.
-
-    - [DetailedError](errors.md#DetailedError) 
-      ```json
-      {
-        "type": "HLUnprocessableEntity",
-        "title": "The following parameters do not conform to the specified format",
-        "invalidParams": [
-          {
-            "name": "string",
-            "reason": "string"
-          }
-        ]
-      }
-      ```
-       - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
-       For detailed informations see [Input Checks](#Checks).
-
 ### GetOperations
 - ID = getOperations
 - Send
+    - operationIds :: List\<String\> (optional)
     - existingEnrollmentId :: String (optional)
     - missingEnrollmentId :: String (optional)
     - initiatorEnrollmentId :: String (optional)
@@ -132,6 +118,9 @@ The Errors returned are defined [here](errors.md#Errors).
 ## <a id="Models" />Models
 
 ### <a id="OperationData" />OperationData
+The operationId in OperationData is constructed as follows:  
+operationId = SHA256($contractName:$transactionName:$parameters)  
+with the String given to the hash function being UTF8 encoded.
 ```json
 {
   "operationId" : "0424974c68530290458c8d58674e2637f65abc127057957d7b3acbd24c208f93",

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -111,7 +111,7 @@ The Errors returned are defined [here](errors.md#Errors).
     - missingEnrollmentId :: String (optional)
     - initiatorEnrollmentId :: String (optional)
     - involvedEnrollmentId :: String (optional)
-    - state :: List\<String\> (optional)
+    - states :: List\<String\> (optional)
 - Receive
     - operationsList :: List\<[OperationData](#OperationData)\>
       - Description: Returns the full list of existing Operations matching the filter parameters.

--- a/hlf/scala/general-communication.md
+++ b/hlf/scala/general-communication.md
@@ -97,7 +97,7 @@ The transactionResult is the chaincode response to the desired transaction
 
 If submitSignedTransaction succeeds, the approval of the User has been stored on the OperationContract.  
 If executeTransaction succeeds, the "real" transaction (e.g. "AddCertificate") is executed.  
-If the approval or the "real" transaction fails due to the transaction itself being invalid (e.g. due to changed ledger state), the operation is rejected.
+If the approval or the "real" transaction fails due to the transaction itself being invalid (e.g. due to changed ledger state), the operation is rejected by the chain.
 
 ========================  
 

--- a/hlf/scala/general-communication.md
+++ b/hlf/scala/general-communication.md
@@ -87,9 +87,11 @@ val transactionBytes = operationConnection.getUnsignedTransaction(proposalBytes:
 ```scala
 val approvalResult = operationConnection.submitSignedTransaction(transactionBytes: Array[Byte], signatureBytes: Array[Byte])
 
-val transactionResult = operationConnection.executeTransaction(jsonOperationData: String)
+val transactionResult = operationConnection.executeTransaction(jsonOperationData: String, timeoutMilliseconds: int = 5000)
 ```
-The approvalResult is a JsonObject [OperationData](../chaincode/operation.md#OperationData). Invoking executeTransactionFromOperation executes the transaction described by the transactionInfo in the OperationData.  
+The approvalResult is a JsonObject [OperationData](../chaincode/operation.md#OperationData). 
+Invoking executeTransactionFromOperation executes the transaction described by the transactionInfo in the OperationData.
+In case of a NetworkException, the transaction is retried until the specified timeout is reached.
 The transactionResult is the chaincode response to the desired transaction
 (e.g. an InsufficientApproval Error, or information about the successfully changed ledger state).
 

--- a/hlf/scala/general-communication.md
+++ b/hlf/scala/general-communication.md
@@ -89,10 +89,11 @@ val (approvalResult, realTransactionResult) = operationConnection.submitSignedTr
 ```
 The approvalResult is a JsonObject [OperationData](../chaincode/operation.md#OperationData).
 The realTransactionResult is the chaincode response to the desired transaction
-(e.g. an InsufficientApproval Error, or information about the successfully changed ledger state)
+(e.g. an InsufficientApproval Error, or information about the successfully changed ledger state).
 
 The approval of the User has been stored on the OperationContract.
-An attempt has been made to execute the "real" transaction (e.g. "AddCertificate")
+An attempt has been made to execute the "real" transaction (e.g. "AddCertificate").
+If the approval or the "real" transaction fails due to the transaction itself being invalid (e.g. due to changed ledger state), the operation is rejected.
 
 ========================  
 

--- a/hlf/scala/operation.md
+++ b/hlf/scala/operation.md
@@ -31,7 +31,7 @@ Additionally, as described in [General Communication](general-communication.md),
           - If the state of data on the ledger is not consistent with the curent model.
             - This error should only occurr if the model changes while the old ledger state remains without modification.
 
-## RejectOperation(operationId: String, rejectMessage: String)
+## <a id="RejectOperation" /> RejectOperation(operationId: String, rejectMessage: String)
 - Returns
     - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
         - => Success
@@ -44,7 +44,7 @@ Additionally, as described in [General Communication](general-communication.md),
           - If the state of data on the ledger is not consistent with the curent model.
             - This error should only occurr if the model changes while the old ledger state remains without modification.
 
-## GetOperations(operationIds: List\<String\>, existingEnrollmentId: String, missingEnrollmentId: String, initiatorEnrollmentId: String, involvedEnrollmentId: String, state: List\<String\>)
+## GetOperations(operationIds: List\<String\>, existingEnrollmentId: String, missingEnrollmentId: String, initiatorEnrollmentId: String, involvedEnrollmentId: String, states: List\<String\>)
 
 Gets the full List of existing Operations.
 Applies filters to match operationId, enrollmendId, state.

--- a/hlf/scala/operation.md
+++ b/hlf/scala/operation.md
@@ -10,7 +10,7 @@ For "operation" handling we offer the following interface.
 Additionally, as described in [General Communication](general-communication.md), different proposal calls can be made.
 
 
-## ProposeTransaction(contractName: String, transactionName: String, params: String*))
+## InitiateOperation(initiator: String, contractName: String, transactionName: String, params: String*))
 - Returns
     - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
         - => Success

--- a/hlf/scala/operation.md
+++ b/hlf/scala/operation.md
@@ -44,16 +44,19 @@ Additionally, as described in [General Communication](general-communication.md),
           - If the state of data on the ledger is not consistent with the curent model.
             - This error should only occurr if the model changes while the old ledger state remains without modification.
 
-## GetOperations(operationIds: String, existingEnrollmentId: String, missingEnrollmentId: String, initiatorEnrollmentId: String, state: String)
+## GetOperations(operationIds: List\<String\>, existingEnrollmentId: String, missingEnrollmentId: String, initiatorEnrollmentId: String, involvedEnrollmentId: String, state: List\<String\>)
 
 Gets the full List of existing Operations.
 Applies filters to match operationId, enrollmendId, state.
 If any of theses parameter is empty, its filter will not be applied.
 - Returns
     - OperationsList :: List\<String Json (refer to: [OperationData](../chaincode/operation.md#OperationData))\> 
-        - =>    Exhaustive List of all Operations, filtered by the parameters.
-                All filters are applied consecutively (logical AND).
-                Empty if no match could be found.
+      - Description: Returns the full list of existing Operations matching the filter parameters.
+        All filters are applied consecutively (logical AND).
+      - If all these parameters are empty, the exhaustive list of all existing Operations is returned.
+      - "involvedEnrollmentId" represents an OR-Filter for existing-/missing-/initiator-enrollmentId
+      - List parameters are also a logical OR over all their entries
+
 
 > Note! Invalid States on the ledger get ignored.
 > We return all valid Operations that match the filters.

--- a/hlf/scala/operation.md
+++ b/hlf/scala/operation.md
@@ -10,7 +10,7 @@ For "operation" handling we offer the following interface.
 Additionally, as described in [General Communication](general-communication.md), different proposal calls can be made.
 
 
-## ApproveTransaction(contractName: String, transactionName: String, params: String*))
+## ProposeTransaction(contractName: String, transactionName: String, params: String*))
 - Returns
     - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
         - => Success
@@ -18,7 +18,7 @@ Additionally, as described in [General Communication](general-communication.md),
         - => error is returned
           - If the given parameters could not be parsed.
 
-## RejectTransaction(operationId: String, rejectMessage: String)
+## <a id="ApproveOperation" /> ApproveOperation(operationId: String)
 - Returns
     - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
         - => Success
@@ -31,10 +31,23 @@ Additionally, as described in [General Communication](general-communication.md),
           - If the state of data on the ledger is not consistent with the curent model.
             - This error should only occurr if the model changes while the old ledger state remains without modification.
 
-## GetOperations(existingEnrollmentId: String, missingEnrollmentId: String, initiatorEnrollmentId: String, state: String)
+## RejectOperation(operationId: String, rejectMessage: String)
+- Returns
+    - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
+        - => Success
+    - TransactionError :: Json (refer to: [DetailedError](../chaincode/errors.md#DetailedError))
+        - => error is returned
+          - If the given parameters could not be parsed.
+    - TransactionError :: Json (refer to: [GenericError](../chaincode/errors.md#GenericError))
+        - => error is returned
+          - If the operationId is not present on the ledger.
+          - If the state of data on the ledger is not consistent with the curent model.
+            - This error should only occurr if the model changes while the old ledger state remains without modification.
+
+## GetOperations(operationIds: String, existingEnrollmentId: String, missingEnrollmentId: String, initiatorEnrollmentId: String, state: String)
 
 Gets the full List of existing Operations.
-Applies filters to match enrollmendId, state.
+Applies filters to match operationId, enrollmendId, state.
 If any of theses parameter is empty, its filter will not be applied.
 - Returns
     - OperationsList :: List\<String Json (refer to: [OperationData](../chaincode/operation.md#OperationData))\> 
@@ -45,16 +58,4 @@ If any of theses parameter is empty, its filter will not be applied.
 > Note! Invalid States on the ledger get ignored.
 > We return all valid Operations that match the filters.
 
-## GetOperationData(operationId: String)
 
-- Returns
-    - OperationData :: Json (refer to: [OperationData](../chaincode/operation.md#OperationData))
-        - => Success
-    - TransactionError :: Json (refer to: [DetailedError](../chaincode/errors.md#DetailedError))
-        - => error is returned
-          - If the given parameters could not be parsed.
-    - TransactionError :: Json (refer to: [GenericError](../chaincode/errors.md#GenericError))
-        - => error is returned
-          - If the operationId is not present on the ledger.
-          - If the state of data on the ledger is not consistent with the curent model.
-            - This error should only occurr if the model changes while the old ledger state remains without modification.


### PR DESCRIPTION
### Reason for this PR
- Fronted signing gets a new workflow, which needs to be incorporated into the api

### Changes in this PR
- Added frontend signing support for rejection of operations
- Moved submitting signed proposal and transaction completely to operation