### PR TITLE
Add operation not pending error

### DIFF
--- a/hlf/chaincode/admission.md
+++ b/hlf/chaincode/admission.md
@@ -46,8 +46,8 @@ The Errors returned are defined [here](errors.md#Errors).
     - [GenericError](errors.md#GenericError) 
       ```json
       {
-        "type": "HLOperationNotPending",
-        "title": "The operation is not PENDING anymore"
+        "type": "HLExecutionImpossible",
+        "title": "The operation is not in pending state"
       }
       ```
        - Description: This error is returned, if the operation for this transaction is not pending.
@@ -99,8 +99,8 @@ The Errors returned are defined [here](errors.md#Errors).
     - [GenericError](errors.md#GenericError) 
       ```json
       {
-        "type": "HLOperationNotPending",
-        "title": "The operation is not PENDING anymore"
+        "type": "HLExecutionImpossible",
+        "title": "The operation is not in pending state"
       }
       ```
        - Description: This error is returned, if the operation for this transaction is not pending.

--- a/hlf/chaincode/admission.md
+++ b/hlf/chaincode/admission.md
@@ -42,6 +42,15 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
       - Description: This error is returned, if the required approvals are not present.
+    
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLOperationNotPending",
+        "title": "The operation is not PENDING anymore"
+      }
+      ```
+       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 ### Drop Admission
@@ -86,6 +95,15 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
       - Description: This error is returned, if the required approvals are not present.
+    
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLOperationNotPending",
+        "title": "The operation is not PENDING anymore"
+      }
+      ```
+       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 ### Get Admissions

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -47,6 +47,15 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
       - Description: This error is returned, if the required approvals are not present.
+    
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLOperationNotPending",
+        "title": "The operation is not PENDING anymore"
+      }
+      ```
+       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 
@@ -164,6 +173,15 @@ This method adds a single entry to the list of semesters in the MatriculationDat
       }
       ```
       - Description: This error is returned, if the required approvals are not present.
+    
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLOperationNotPending",
+        "title": "The operation is not PENDING anymore"
+      }
+      ```
+       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 ## <a id="Models" />Models

--- a/hlf/chaincode/matriculation.md
+++ b/hlf/chaincode/matriculation.md
@@ -51,8 +51,8 @@ The Errors returned are defined [here](errors.md#Errors).
     - [GenericError](errors.md#GenericError) 
       ```json
       {
-        "type": "HLOperationNotPending",
-        "title": "The operation is not PENDING anymore"
+        "type": "HLExecutionImpossible",
+        "title": "The operation is not in pending state"
       }
       ```
        - Description: This error is returned, if the operation for this transaction is not pending.
@@ -177,8 +177,8 @@ This method adds a single entry to the list of semesters in the MatriculationDat
     - [GenericError](errors.md#GenericError) 
       ```json
       {
-        "type": "HLOperationNotPending",
-        "title": "The operation is not PENDING anymore"
+        "type": "HLExecutionImpossible",
+        "title": "The operation is not in pending state"
       }
       ```
        - Description: This error is returned, if the operation for this transaction is not pending.

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -34,6 +34,15 @@ The Errors returned are defined [here](errors.md#Errors).
       ```
        - Description: This error is returned, if the user trying to approve is not allowed to approve the operation.
 
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLOperationNotPending",
+        "title": "The operation is not PENDING anymore"
+      }
+      ```
+       - Description: This error is returned, if the user is trying to approve an operation that is not pending.
+
     - [DetailedError](errors.md#DetailedError) 
       ```json
       {
@@ -67,6 +76,15 @@ The Errors returned are defined [here](errors.md#Errors).
       }
       ```
        - Description: This error is returned, if the user trying to reject is not allowed to reject the operation.
+    
+    - [GenericError](errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLOperationNotPending",
+        "title": "The operation is not PENDING anymore"
+      }
+      ```
+       - Description: This error is returned, if the user is trying to reject an operation that is not pending.
 
     - [GenericError](errors.md#GenericError) 
       ```json

--- a/hlf/chaincode/operation.md
+++ b/hlf/chaincode/operation.md
@@ -37,8 +37,8 @@ The Errors returned are defined [here](errors.md#Errors).
     - [GenericError](errors.md#GenericError) 
       ```json
       {
-        "type": "HLOperationNotPending",
-        "title": "The operation is not PENDING anymore"
+        "type": "HLApprovalImpossible",
+        "title": "The operation is not in pending state"
       }
       ```
        - Description: This error is returned, if the user is trying to approve an operation that is not pending.
@@ -80,8 +80,8 @@ The Errors returned are defined [here](errors.md#Errors).
     - [GenericError](errors.md#GenericError) 
       ```json
       {
-        "type": "HLOperationNotPending",
-        "title": "The operation is not PENDING anymore"
+        "type": "HLRejectionImpossible",
+        "title": "The operation is not in pending state"
       }
       ```
        - Description: This error is returned, if the user is trying to reject an operation that is not pending.


### PR DESCRIPTION
**Reason for this PR:**
- operations that are no longer pending should not be modified anymore
- transactions failing due to the corresponding operation not being pending should state so in their response