### PR TITLE
Generalize ApprovalDenied/RejectionDenied to ParticipationDenied

### DIFF
--- a/hlf/chaincode/contracts/admission.md
+++ b/hlf/chaincode/contracts/admission.md
@@ -39,6 +39,7 @@ The Errors returned are defined [here](../errors.md#Errors).
             For detailed informations see [parameter checks](#parameterChecks).
          - if the given parameters produce some [semantic error](#semanticChecks).
     
+    - additionally all [operation errors](../errors.md#AllOperations) can be thrown
 
 
 ### Drop Admission
@@ -79,6 +80,8 @@ The Errors returned are defined [here](../errors.md#Errors).
       - Description: This error is returned, if the given parameters are not well formatted, they are listed in invalidParams.  
       For detailed informations see [parameter checks](#parameterChecks).
       (admissionId)
+    
+    - additionally all [operation errors](../errors.md#AllOperations) can be thrown
 
 
 

--- a/hlf/chaincode/contracts/admission.md
+++ b/hlf/chaincode/contracts/admission.md
@@ -39,23 +39,6 @@ The Errors returned are defined [here](../errors.md#Errors).
             For detailed informations see [parameter checks](#parameterChecks).
          - if the given parameters produce some [semantic error](#semanticChecks).
     
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
-    
-    - [GenericError](errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLExecutionImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 ### Drop Admission
@@ -97,23 +80,6 @@ The Errors returned are defined [here](../errors.md#Errors).
       For detailed informations see [parameter checks](#parameterChecks).
       (admissionId)
 
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
-    
-    - [GenericError](errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLExecutionImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 ### Get Course Admissions

--- a/hlf/chaincode/contracts/exam.md
+++ b/hlf/chaincode/contracts/exam.md
@@ -38,14 +38,6 @@ The Errors returned are defined [here](../errors.md#Errors).
          - if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
             For detailed informations see [Input Checks](#Checks).
     
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
 
 ### Get Exams
 - ID = getExams

--- a/hlf/chaincode/contracts/exam.md
+++ b/hlf/chaincode/contracts/exam.md
@@ -38,6 +38,8 @@ The Errors returned are defined [here](../errors.md#Errors).
          - if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
             For detailed informations see [Input Checks](#Checks).
     
+    - additionally all [operation errors](../errors.md#AllOperations) can be thrown
+    
 
 ### Get Exams
 - ID = getExams

--- a/hlf/chaincode/contracts/examResult.md
+++ b/hlf/chaincode/contracts/examResult.md
@@ -38,14 +38,6 @@ The Errors returned are defined [here](../errors.md#Errors).
          - if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
             For detailed informations see [Input Checks](#Checks).
     
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
 
 ### Get Exam Result Entries
 - ID = getExamResultEntries

--- a/hlf/chaincode/contracts/examResult.md
+++ b/hlf/chaincode/contracts/examResult.md
@@ -38,6 +38,8 @@ The Errors returned are defined [here](../errors.md#Errors).
          - if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
             For detailed informations see [Input Checks](#Checks).
     
+    - additionally all [operation errors](../errors.md#AllOperations) can be thrown
+    
 
 ### Get Exam Result Entries
 - ID = getExamResultEntries

--- a/hlf/chaincode/contracts/group.md
+++ b/hlf/chaincode/contracts/group.md
@@ -36,15 +36,6 @@ The Errors returned are defined [here](../errors.md#Errors).
          - if the given parameters could not be parsed. If some attributes within the json are not well formatted, they are listed in invalidParams.  
             For detailed informations see [parameter checks](#parameterChecks).
          - if the given parameters produce some [semantic error](#semanticChecks).
-    
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
 
 
 ### Remove From Group
@@ -82,14 +73,6 @@ The Errors returned are defined [here](../errors.md#Errors).
       For detailed informations see [parameter checks](#parameterChecks).
       (enrollmentId, groupId)
 
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
 
 ### Remove User From All Groups
 - ID = removeUserFromAllGroups
@@ -124,15 +107,6 @@ The Errors returned are defined [here](../errors.md#Errors).
       - Description: This error is returned, if the given parameters are not well formatted, they are listed in invalidParams.  
       For detailed informations see [parameter checks](#parameterChecks).
       (enrollmentId)
-
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
 
 
 

--- a/hlf/chaincode/contracts/matriculation.md
+++ b/hlf/chaincode/contracts/matriculation.md
@@ -45,24 +45,6 @@ The Errors returned are defined [here](../errors.md#Errors).
       ```
       - Description: This error is returned, if a matriculation data with the given enrollmentId is already present on the ledger.
 
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
-    
-    - [GenericError](errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLExecutionImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the operation for this transaction is not pending.
-
 
 
 
@@ -176,24 +158,6 @@ This method adds a single entry to the list of semesters in the MatriculationDat
       }
       ```
       - Description: This error is returned, if the state of data on the ledger is not consistent with the curent model. This error should only occurr if the model changes while the old ledger state remains without modification.
-    
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLInsufficientApprovals",
-        "title": "The approvals present on the ledger do not suffice to execute this transaction"
-      }
-      ```
-      - Description: This error is returned, if the required approvals are not present.
-    
-    - [GenericError](errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLExecutionImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the operation for this transaction is not pending.
 
 
 ## <a id="Models" />Models

--- a/hlf/chaincode/contracts/matriculation.md
+++ b/hlf/chaincode/contracts/matriculation.md
@@ -44,6 +44,8 @@ The Errors returned are defined [here](../errors.md#Errors).
       }
       ```
       - Description: This error is returned, if a matriculation data with the given enrollmentId is already present on the ledger.
+    
+    - additionally all [operation errors](../errors.md#AllOperations) can be thrown
 
 
 
@@ -158,6 +160,8 @@ This method adds a single entry to the list of semesters in the MatriculationDat
       }
       ```
       - Description: This error is returned, if the state of data on the ledger is not consistent with the curent model. This error should only occurr if the model changes while the old ledger state remains without modification.
+
+    - additionally all [operation errors](../errors.md#AllOperations) can be thrown
 
 
 ## <a id="Models" />Models

--- a/hlf/chaincode/contracts/operation.md
+++ b/hlf/chaincode/contracts/operation.md
@@ -52,6 +52,15 @@ The Errors returned are defined [here](../errors.md#Errors).
 - Receive
     - operationData :: [OperationData](#OperationData) 
       -  Description: Success, returns the list of operations.
+    
+    - [GenericError](../errors.md#GenericError) 
+      ```json
+      {
+        "type": "HLUnprocessableLedgerState",
+        "title": "The state on the ledger does not conform to the specified format"
+      }
+      ```
+      - Description: This error is returned, if the state of data on the ledger is not consistent with the current model. This error should only occur if the model changes while the old ledger state remains without modification.
 
     - [GenericError](../errors.md#GenericError) 
       ```json
@@ -77,6 +86,15 @@ The Errors returned are defined [here](../errors.md#Errors).
       ```
        - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
        For detailed informations see [Input Checks](#Checks).
+    
+    - [GenericError](#GenericError) 
+      ```json
+      {
+        "type": "HLExecutionImpossible",
+        "title": "The operation is not in pending state"
+      }
+      ```
+      - Description: This error is returned, if the operation for this transaction is not pending.
 
 ### RejectOperation
 - ID = rejectOperation
@@ -119,6 +137,15 @@ The Errors returned are defined [here](../errors.md#Errors).
       ```
        - Description: This error is returned, if the given parameters could not be parsed. If some attributes are not well formatted, they are listed in invalidParams.  
        For detailed informations see [Input Checks](#Checks).
+    
+    - [GenericError](#GenericError) 
+      ```json
+      {
+        "type": "HLExecutionImpossible",
+        "title": "The operation is not in pending state"
+      }
+      ```
+      - Description: This error is returned, if the operation for this transaction is not pending.
 
 ### GetOperations
 - ID = getOperations

--- a/hlf/chaincode/contracts/operation.md
+++ b/hlf/chaincode/contracts/operation.md
@@ -27,24 +27,6 @@ The Errors returned are defined [here](../errors.md#Errors).
       }
       ```
        - Description: This error is returned, if the given number of parameters for the specified transaction does not match the number of required parameters.
-    
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLParticipationDenied",
-        "title": "You are not allowed to participate in the given operation"
-      }
-      ```
-       - Description: This error is returned, if the user trying to approve is not allowed to participate the operation.
-
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLParticipationImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the user is trying to approve an operation that is not pending.
 
     - [DetailedError](../errors.md#DetailedError) 
       ```json
@@ -70,24 +52,6 @@ The Errors returned are defined [here](../errors.md#Errors).
 - Receive
     - operationData :: [OperationData](#OperationData) 
       -  Description: Success, returns the list of operations.
-    
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLParticipationDenied",
-        "title": "You are not allowed to participate in the given operation"
-      }
-      ```
-       - Description: This error is returned, if the user trying to reject is not allowed to participate in the operation.
-
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLParticipationImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the user is trying to reject an operation that is not pending
 
     - [GenericError](../errors.md#GenericError) 
       ```json
@@ -122,24 +86,6 @@ The Errors returned are defined [here](../errors.md#Errors).
 - Receive
     - operationData :: [OperationData](#OperationData) 
       -  Description: Success, returns the list of operations.
-
-    - [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLParticipationDenied",
-        "title": "You are not allowed to participate in the given operation"
-      }
-      ```
-       - Description: This error is returned, if the user trying to reject is not allowed to participate in the operation.
-
-- [GenericError](../errors.md#GenericError) 
-      ```json
-      {
-        "type": "HLParticipationImpossible",
-        "title": "The operation is not in pending state"
-      }
-      ```
-       - Description: This error is returned, if the user is trying to reject an operation that is not pending
 
     - [GenericError](../errors.md#GenericError) 
       ```json

--- a/hlf/chaincode/contracts/operation.md
+++ b/hlf/chaincode/contracts/operation.md
@@ -1,4 +1,4 @@
-# Hyperledger Operation Api
+# <a id="OperationApi" />Hyperledger Operation Api
 
 In the following, the chaincode api for the "Operation"-Chaincode is described.
 This contains all Transactions and Models provided for this domain.
@@ -31,16 +31,16 @@ The Errors returned are defined [here](../errors.md#Errors).
     - [GenericError](../errors.md#GenericError) 
       ```json
       {
-        "type": "HLApprovalDenied",
-        "title": "You are not allowed to approve the given operation"
+        "type": "HLParticipationDenied",
+        "title": "You are not allowed to participate in the given operation"
       }
       ```
-       - Description: This error is returned, if the user trying to approve is not allowed to approve the operation.
+       - Description: This error is returned, if the user trying to approve is not allowed to participate the operation.
 
     - [GenericError](../errors.md#GenericError) 
       ```json
       {
-        "type": "HLApprovalImpossible",
+        "type": "HLParticipationImpossible",
         "title": "The operation is not in pending state"
       }
       ```
@@ -74,16 +74,16 @@ The Errors returned are defined [here](../errors.md#Errors).
     - [GenericError](../errors.md#GenericError) 
       ```json
       {
-        "type": "HLApprovalDenied",
-        "title": "You are not allowed to approve the given operation"
+        "type": "HLParticipationDenied",
+        "title": "You are not allowed to participate in the given operation"
       }
       ```
-       - Description: This error is returned, if the user trying to reject is not allowed to reject the operation.
+       - Description: This error is returned, if the user trying to reject is not allowed to participate in the operation.
 
     - [GenericError](../errors.md#GenericError) 
       ```json
       {
-        "type": "HLApprovalImpossible",
+        "type": "HLParticipationImpossible",
         "title": "The operation is not in pending state"
       }
       ```
@@ -123,19 +123,19 @@ The Errors returned are defined [here](../errors.md#Errors).
     - operationData :: [OperationData](#OperationData) 
       -  Description: Success, returns the list of operations.
 
-    - [GenericError](errors.md#GenericError) 
+    - [GenericError](../errors.md#GenericError) 
       ```json
       {
-        "type": "HLRejectionDenied",
-        "title": "You are not allowed to reject the given operation"
+        "type": "HLParticipationDenied",
+        "title": "You are not allowed to participate in the given operation"
       }
       ```
-       - Description: This error is returned, if the user trying to reject is not allowed to reject the operation.
+       - Description: This error is returned, if the user trying to reject is not allowed to participate in the operation.
 
 - [GenericError](../errors.md#GenericError) 
       ```json
       {
-        "type": "HLRejectionImpossible",
+        "type": "HLParticipationImpossible",
         "title": "The operation is not in pending state"
       }
       ```

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -54,7 +54,7 @@ In the following, the specific error that can be returned by every transaction n
 - [GenericError](#GenericError) 
   ```json
   {
-    "type": "HLExecutionImpossible",
+    "type": "HLParticipationImpossible",
     "title": "The operation is not in pending state"
   }
   ```

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -42,8 +42,21 @@ reason:
 
 ## <a id="AllTransactions" />All Transactions
 
-In the following, the specific errors that can be returned by every transaction due to our operation workflow are defined.
+In the following, the specific errors that can be returned by every transaction.
 
+- [GenericError](#GenericError) 
+  ```json
+  {
+    "type": "HLAccessDenied",
+    "title": "You are not allowed to execute the given transaction"
+  }
+  ```
+    - Description: This error is returned, if the user is not allowed to execute the transaction.
+
+## <a id="AllOperations" />All Operations
+
+In the following, the specific errors that can additionally be returned by every operation are defined.
+An operation is a transaction requiring multiple approvals.
 
 - [GenericError](#GenericError) 
   ```json
@@ -53,20 +66,6 @@ In the following, the specific errors that can be returned by every transaction 
   }
   ```
   - Description: This error is returned, if the required approvals are not present.
-
-- [GenericError](#GenericError) 
-  ```json
-  {
-    "type": "HLAccessDenied",
-    "title": "You are not allowed to execute the given transaction"
-  }
-  ```
-    - Description: This error is returned, if the user trying to execute the transaction is not allowed to participate in the operation.
-
-
-## <a id="AllOperations" />All Operations
-
-In the following, the specific errors that can additionally be returned by every operation are defined.
 
 - [GenericError](#GenericError) 
   ```json

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -40,7 +40,8 @@ reason:
 
 # Specific Errors
 
-In the following, the specific error that can be returned by every transaction not part of the [OperationContract](./contracts/operation.md#OperationApi)  due to our operation workflow.
+In the following, the specific error that can be returned by every transaction due to our operation workflow.
+
 
 - [GenericError](#GenericError) 
   ```json

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -36,3 +36,35 @@ name:
 
 reason:
 - a textual representation of why the parameter is invalid
+
+
+# Specific Errors
+
+In the following, the specific error that can be returned by every transaction not part of the [OperationContract](./contracts/operation.md#OperationApi)  due to our operation workflow.
+
+- [GenericError](#GenericError) 
+  ```json
+  {
+    "type": "HLInsufficientApprovals",
+    "title": "The approvals present on the ledger do not suffice to execute this transaction"
+  }
+  ```
+  - Description: This error is returned, if the required approvals are not present.
+
+- [GenericError](#GenericError) 
+  ```json
+  {
+    "type": "HLExecutionImpossible",
+    "title": "The operation is not in pending state"
+  }
+  ```
+  - Description: This error is returned, if the operation for this transaction is not pending.
+
+- [GenericError](#GenericError) 
+  ```json
+  {
+    "type": "HLParticipationDenied",
+    "title": "You are not allowed to participate in the given operation"
+  }
+  ```
+    - Description: This error is returned, if the user trying to execute the transaction is not allowed to participate in the operation.

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -40,7 +40,9 @@ reason:
 
 # Specific Errors
 
-In the following, the specific error that can be returned by every transaction due to our operation workflow.
+## <a id="AllTransactions" />All Transactions
+
+In the following, the specific errors that can be returned by every transaction due to our operation workflow are defined.
 
 
 - [GenericError](#GenericError) 
@@ -55,17 +57,22 @@ In the following, the specific error that can be returned by every transaction d
 - [GenericError](#GenericError) 
   ```json
   {
+    "type": "HLAccessDenied",
+    "title": "You are not allowed to execute the given transaction"
+  }
+  ```
+    - Description: This error is returned, if the user trying to execute the transaction is not allowed to participate in the operation.
+
+
+## <a id="AllOperations" />All Operations
+
+In the following, the specific errors that can additionally be returned by every operation are defined.
+
+- [GenericError](#GenericError) 
+  ```json
+  {
     "type": "HLParticipationImpossible",
     "title": "The operation is not in pending state"
   }
   ```
   - Description: This error is returned, if the operation for this transaction is not pending.
-
-- [GenericError](#GenericError) 
-  ```json
-  {
-    "type": "HLAccessDenied",
-    "title": "You are not allowed to execute in the given transaction"
-  }
-  ```
-    - Description: This error is returned, if the user trying to execute the transaction is not allowed to participate in the operation.

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -63,8 +63,8 @@ In the following, the specific error that can be returned by every transaction n
 - [GenericError](#GenericError) 
   ```json
   {
-    "type": "HLParticipationDenied",
-    "title": "You are not allowed to participate in the given operation"
+    "type": "HLAccessDenied",
+    "title": "You are not allowed to execute in the given transaction"
   }
   ```
     - Description: This error is returned, if the user trying to execute the transaction is not allowed to participate in the operation.

--- a/hlf/chaincode/errors.md
+++ b/hlf/chaincode/errors.md
@@ -71,7 +71,7 @@ In the following, the specific errors that can additionally be returned by every
 - [GenericError](#GenericError) 
   ```json
   {
-    "type": "HLParticipationImpossible",
+    "type": "HLExecutionImpossible",
     "title": "The operation is not in pending state"
   }
   ```


### PR DESCRIPTION
### Reason for this PR:
- to avoid leaking sensitive data, transactions should only be executable by users required to approve the transaction

### Changes in this PR:
- generalize approval denied and rejection denied errors to participation denied error
- add participation denied error to errors throwable by transactions utilizing our operation workflow
- outsource errors related to our operation workflow from transactions to general error definition